### PR TITLE
Intervals

### DIFF
--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -241,6 +241,9 @@ class PitchClass:
         elif isinstance(x, PitchClass):
             vnew = self.value + x.with_root(self.root).value
             return PitchClass(vnew, root=self.root)
+        elif isinstance(x, SimpleInterval):
+            # elif type(x) is SimpleInterval:
+            return PitchClass(self.value + x.value, root=self.root)
         else:
             return NotImplemented
 
@@ -257,7 +260,12 @@ class PitchClass:
         return -1 * self
 
     def __sub__(self, x):
-        return self + -x
+        if isinstance(x, int):
+            return self + -x
+        elif isinstance(x, type(self)):
+            return SimpleInterval(self.value - x.value)
+        else:
+            return NotImplemented
 
 
 # TODO: .from_name as alias for .from_spn / .from_scientific_pitch_notation
@@ -396,24 +404,24 @@ class Pitch:
 
     def __eq__(self, other):
         # Only for other Pitch instances
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
 
         return self.value == other.value
 
     def __lt__(self, other):
         # Only for other Pitch instances
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, type(self)):
             return NotImplemented
 
         return self.value < other.value
 
     def __add__(self, x):
         if isinstance(x, int):
-            return self.__class__(self.value + x)
-        elif isinstance(x, self.__class__):
+            return type(self)(self.value + x)
+        elif isinstance(x, (type(self), SimpleInterval)):
             # Adding chromatic-value-wise, not frequency-wise!
-            return self.__class__(self.value + x.value)
+            return type(self)(self.value + x.value)
         else:
             return NotImplemented
 
@@ -421,7 +429,7 @@ class Pitch:
         if not isinstance(x, int):
             return NotImplemented
 
-        return self.__class__(x * self.value)
+        return type(self)(x * self.value)
 
     def __rmul__(self, x):
         return self * x
@@ -430,7 +438,14 @@ class Pitch:
         return -1 * self
 
     def __sub__(self, x):
-        return self + -x
+        if isinstance(x, int):
+            return self + -x
+        elif isinstance(x, SimpleInterval):
+            return self + -x.value
+        elif isinstance(x, type(self)):
+            return SignedInterval(self.value - x.value)
+        else:
+            return NotImplemented
 
 
 # TODO: make the note types hashable

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -434,3 +434,66 @@ class Pitch:
 
 
 # TODO: make the note types hashable
+
+
+# https://en.wikipedia.org/wiki/File:Main_intervals_from_C.png
+MAIN_INTERVAL_SHORT_NAMES = [
+    "P1",
+    "m2",
+    "M2",
+    "m3",
+    "M3",
+    "P4",
+    "A4",
+    "P5",
+    "m6",
+    "M6",
+    "m7",
+    "M7",
+    "P8",
+]
+
+
+@functools.total_ordering
+class SimpleInterval:
+    """An interval that is at most one octave."""
+
+    def __init__(self, value: int) -> None:
+
+        if 0 <= value <= 12:
+            value_ = value
+        else:
+            abs_value = abs(value)
+            mod_abs_value = abs_value % 12
+            if mod_abs_value == 0 and abs_value >= 12:
+                value_ = 12
+            else:
+                value_ = mod_abs_value
+            warnings.warn(
+                f"input value {value} not between 0 and 12 " f"has been coerced to {value_}"
+            )
+        self.value = value_
+        """Number of semitones."""
+
+    @property
+    def name(self) -> str:
+        """Major, minor, or perfect interval short name."""
+        return MAIN_INTERVAL_SHORT_NAMES[self.value]
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(value={self.value})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return self.value == other.value
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return self.value < other.value

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -456,7 +456,9 @@ MAIN_INTERVAL_SHORT_NAMES = [
 
 @functools.total_ordering
 class SimpleInterval:
-    """An interval that is at most one octave."""
+    """An interval that is at most one octave.
+    Direction, e.g., in a melodic interval, is not incorporated.
+    """
 
     def __init__(self, value: int) -> None:
 
@@ -473,12 +475,16 @@ class SimpleInterval:
                 f"input value {value} not between 0 and 12 " f"has been coerced to {value_}"
             )
         self.value = value_
-        """Number of semitones."""
+        """Number of semitones (half-steps)."""
 
     @property
     def name(self) -> str:
         """Major, minor, or perfect interval short name."""
         return MAIN_INTERVAL_SHORT_NAMES[self.value]
+
+    @property
+    def whole_steps(self) -> float:
+        return self.value / 2
 
     def __str__(self) -> str:
         return self.name
@@ -497,3 +503,41 @@ class SimpleInterval:
             return NotImplemented
 
         return self.value < other.value
+
+
+class SignedInterval(SimpleInterval):
+    """An interval that can be more than one octave and with sign (direction) included."""
+
+    def __init__(self, value: int) -> None:
+
+        self.value = value
+        """Number of semitones (half-steps)."""
+
+    @property
+    def name(self) -> str:
+        is_neg = self.value < 0
+
+        n_o, i0 = divmod(abs(self.value), 12)
+
+        if n_o >= 2:
+            s_o = f"{n_o}({MAIN_INTERVAL_SHORT_NAMES[-1]})"
+        elif n_o == 1:
+            s_o = f"{MAIN_INTERVAL_SHORT_NAMES[-1]}"
+        else:  # 0
+            s_o = ""
+
+        s_i0 = MAIN_INTERVAL_SHORT_NAMES[i0] if i0 != 0 else ""
+
+        if s_o and not s_i0:
+            s = s_o
+        elif s_i0 and not s_o:
+            s = s_i0
+        elif not s_o and not s_i0:
+            s = MAIN_INTERVAL_SHORT_NAMES[0]
+        else:
+            s = f"{s_o}+{s_i0}"
+
+        if is_neg:
+            s = f"-[{s}]"
+
+        return s

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -505,6 +505,13 @@ class SimpleInterval:
     def inverse(self) -> "SimpleInterval":
         return type(self)(12 - self.value)
 
+    @classmethod
+    def from_name(cls, name: str) -> "SimpleInterval":
+        if name not in MAIN_INTERVAL_SHORT_NAMES:
+            raise ValueError(f"interval name {name!r} not recognized")
+
+        return cls(MAIN_INTERVAL_SHORT_NAMES.index(name))
+
     def __str__(self) -> str:
         return self.name
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -501,6 +501,10 @@ class SimpleInterval:
     def whole_steps(self) -> float:
         return self.value / 2
 
+    @property
+    def inverse(self) -> "SimpleInterval":
+        return type(self)(12 - self.value)
+
     def __str__(self) -> str:
         return self.name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ ignore = [
   "W503", # line break before binary operator
   "E226", # missing whitespace around arithmetic operator - not always more readable imho
 ]
+
+[tool.isort]
+line_length = 100

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -212,3 +212,9 @@ def test_interval_returned_from_pitch_sub():
 def test_add_interval_to_pitch():
     assert Pitch(40) + SignedInterval(-10) == Pitch(30)
     assert PitchClass(0) + SimpleInterval(5) == PitchClass(5)
+
+
+def test_simple_interval_inverse():
+    m3 = SimpleInterval.from_name("m3")
+    assert m3.value == 3
+    assert m3.inverse.name == "M6"

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -175,10 +175,15 @@ def test_note_to_from_abc_consistency():
         (2, "M2"),
         (10, "m7"),
         (12, "P8"),
+        (24, "P8"),
     ],
 )
 def test_simple_interval_name(v, expected_name):
-    assert SimpleInterval(v).name == expected_name
+    if 0 <= v <= 12:
+        assert SimpleInterval(v).name == expected_name
+    else:
+        with pytest.warns(UserWarning):
+            assert SimpleInterval(v).name == expected_name
 
 
 @pytest.mark.parametrize(
@@ -194,3 +199,16 @@ def test_simple_interval_name(v, expected_name):
 )
 def test_signed_interval_name(v, expected_name):
     assert SignedInterval(v).name == expected_name
+
+
+def test_interval_returned_from_pitch_sub():
+    assert Pitch(50) - Pitch(40) == SignedInterval(10)
+    assert Pitch(40) - Pitch(50) == SignedInterval(-10)
+    assert PitchClass(7) - PitchClass(0) == SimpleInterval(7)
+    with pytest.warns(UserWarning):
+        assert PitchClass(0) - PitchClass(7) == SimpleInterval(7)
+
+
+def test_add_interval_to_pitch():
+    assert Pitch(40) + SignedInterval(-10) == Pitch(30)
+    assert PitchClass(0) + SimpleInterval(5) == PitchClass(5)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyabc2.key import Key
 from pyabc2.note import Note
-from pyabc2.pitch import Pitch, PitchClass, SimpleInterval, pitch_class_value
+from pyabc2.pitch import Pitch, PitchClass, SignedInterval, SimpleInterval, pitch_class_value
 
 
 @pytest.mark.parametrize(
@@ -179,3 +179,18 @@ def test_note_to_from_abc_consistency():
 )
 def test_simple_interval_name(v, expected_name):
     assert SimpleInterval(v).name == expected_name
+
+
+@pytest.mark.parametrize(
+    ("v", "expected_name"),
+    [
+        (0, "P1"),
+        (2, "M2"),
+        (3, "m3"),
+        (15, "P8+m3"),
+        (27, "2(P8)+m3"),
+        (-27, "-[2(P8)+m3]"),
+    ],
+)
+def test_signed_interval_name(v, expected_name):
+    assert SignedInterval(v).name == expected_name

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyabc2.key import Key
 from pyabc2.note import Note
-from pyabc2.pitch import Pitch, PitchClass, pitch_class_value
+from pyabc2.pitch import Pitch, PitchClass, SimpleInterval, pitch_class_value
 
 
 @pytest.mark.parametrize(
@@ -166,3 +166,16 @@ def test_note_to_from_abc_consistency():
     assert Note.from_abc(n.to_abc()) == n
 
     assert Note.from_abc(n.to_abc(key=Key("C#")), key=Key("C#")) == n
+
+
+@pytest.mark.parametrize(
+    ("v", "expected_name"),
+    [
+        (0, "P1"),
+        (2, "M2"),
+        (10, "m7"),
+        (12, "P8"),
+    ],
+)
+def test_simple_interval_name(v, expected_name):
+    assert SimpleInterval(v).name == expected_name


### PR DESCRIPTION
* interval types that define their names based on the number of chromatic steps
* subtracting two pitch or pitch class instances now returns an interval instance, which makes more sense I think
* interval instances can be added to pitch / pitch class instances

Something to deal with in the future is that, like note names, interval names are context (key/mode) dependent. For example, C# to Eb (or C to Ebb) is still considered a 3rd, but a diminished 3rd.