### PR TITLE
Unicode reprs for pitch

### DIFF
--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -51,6 +51,7 @@ _ACCIDENTAL_ASCII_TO_HTML = {
     "bb": "&#119083;",
     "##": "&#119082;",
 }
+_TRAN_NUM_TO_UNICODE = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
 
 NICE_C_CHROMATIC_NOTES = ["C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"]
 """ASCII chromatic notes, starting with C at index 0.
@@ -492,6 +493,17 @@ class Pitch:
     def _repr_html_(self):
         cn = self.to_pitch_class()._repr_html_()
         return f"{cn}<sub>{self.octave}</sub>"
+
+    def unicode(self):
+        """String repr using unicode accidental symbols and unicode subscripts for octave.
+
+        .. note::
+           ``str(pitch)`` returns an string representation using ASCII accidental symbols
+           (``#``, ``b``, ``=``).
+        """
+        cn = self.to_pitch_class().unicode()
+        o = str(self.octave).translate(_TRAN_NUM_TO_UNICODE)
+        return f"{cn}{o}"
 
     @property
     def piano_key_number(self) -> int:

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -204,6 +204,15 @@ class PitchClass:
         name = self.name
         return name[0] + "".join(_ACCIDENTAL_ASCII_TO_HTML[c] for c in name[1:])
 
+    def unicode(self):
+        """String repr using unicode accidental symbols.
+
+        .. note::
+           ``str(pitch_class)`` returns an string representation using ASCII accidental symbols
+           (``#``, ``b``, ``=``).
+        """
+        return f"{self.nat}{_ACCIDENTAL_ASCII_TO_UNICODE[self.acc]}"
+
     @classmethod
     def from_pitch(cls, p: "Pitch") -> "PitchClass":
         return cls.from_name(p.class_name)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -152,6 +152,22 @@ def test_pitch_class_unicode(s, expected):
 
 
 @pytest.mark.parametrize(
+    "s, expected",
+    [
+        ("A4", "A₄"),
+        ("A14", "A₁₄"),
+        ("Ab4", "A♭₄"),
+        ("Abb4", "A𝄫₄"),
+        ("A#4", "A♯₄"),
+        ("A##4", "A𝄪₄"),
+        ("A=4", "A♮₄"),
+    ],
+)
+def test_pitch_unicode(s, expected):
+    assert Pitch.from_name(s).unicode() == expected
+
+
+@pytest.mark.parametrize(
     ("abc", "expected_str_rep"),
     [
         # Octave

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -132,7 +132,23 @@ def test_pitch_to_pitch_class():
     assert Pitch(50).to_pitch_class() == D
 
 
+# TODO: test PitchClass name validation
 # TODO: test add/mul Pitch(Class)
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        ("A", "A"),
+        ("Ab", "A♭"),
+        ("Abb", "A𝄫"),
+        ("A#", "A♯"),
+        ("A##", "A𝄪"),
+        ("A=", "A♮"),
+    ],
+)
+def test_pitch_class_unicode(s, expected):
+    assert PitchClass.from_name(s).unicode() == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #18

Multiple subscript octave numbers together doesn't look too good in fixed-width fonts. But the standard octave numbers are all less than 10.

`.unicode()` method