### PR TITLE
Ensure `.octave` consistent with SPN input

### DIFF
--- a/pyabc2/note.py
+++ b/pyabc2/note.py
@@ -184,6 +184,7 @@ class Note(Pitch):
 
         note = cls(value, relative_duration * unit_duration)
         note._class_name = nat_class_name + acc_ascii
+        note._octave = octave
 
         return note
 

--- a/pyabc2/note.py
+++ b/pyabc2/note.py
@@ -238,6 +238,7 @@ class Note(Pitch):
     def from_pitch(cls, p: Pitch, *, duration: Fraction = _DEFAULT_UNIT_DURATION) -> "Note":
         note = cls(p.value, duration)
         note._class_name = p._class_name
+        note._octave = p._octave
 
         return note
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -458,6 +458,7 @@ class Pitch:
         """Chromatic note value relative to C0."""
 
         self._class_name: Optional[str] = None
+        self._octave: Optional[int] = None
 
     @property
     def class_value(self) -> int:
@@ -467,7 +468,10 @@ class Pitch:
     @property
     def octave(self) -> int:
         """Octave number (e.g., A4/A440 is in octave 4)."""
-        return self.value // 12
+        if self._octave is None:
+            return self.value // 12
+        else:
+            return self._octave
 
     @property
     def class_name(self) -> str:
@@ -574,6 +578,7 @@ class Pitch:
 
         p = cls.from_class_value(class_value, octave)
         p._class_name = class_name
+        p._octave = octave
 
         return p
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -612,6 +612,7 @@ class Pitch:
 
         note = Note(self.value, duration=duration)
         note._class_name = self._class_name
+        note._octave = self._octave
 
         return note
 

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -67,12 +67,36 @@ def test_pitch_value_acc_outside_octave(name, expected_value):
         ("C##4", 4),
     ],
 )
-def test_octave_value(name, expected_value):
+def test_pitch_octave_value(name, expected_value):
     # Issue 17
     # https://en.wikipedia.org/wiki/Scientific_pitch_notation#Nomenclature
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="computed pitch class value outside 0--11")
         assert Pitch.from_name(name).octave == expected_value
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_value"),
+    [
+        ("Bbb3", 3),
+        ("Bb3", 3),
+        ("B3", 3),
+        ("B#3", 3),
+        ("B##3", 3),
+        #
+        ("Cbb4", 4),
+        ("Cb4", 4),
+        ("C4", 4),
+        ("C#4", 4),
+        ("C##4", 4),
+    ],
+)
+def test_pitch_from_octave_value(name, expected_value):
+    p = Pitch.from_name(name)
+    assert p.to_note().octave == Note.from_pitch(p).octave == expected_value
+
+
+# test_pitch_octave_value
 
 
 @pytest.mark.parametrize("p", ["C", "Dbb"])

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -91,12 +91,25 @@ def test_pitch_octave_value(name, expected_value):
         ("C##4", 4),
     ],
 )
-def test_pitch_from_octave_value(name, expected_value):
-    p = Pitch.from_name(name)
-    assert p.to_note().octave == Note.from_pitch(p).octave == expected_value
+def test_note_from_pitch_octave_value(name, expected_value):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="computed pitch class value outside 0--11")
+        p = Pitch.from_name(name)
+        assert p.to_note().octave == Note.from_pitch(p).octave == expected_value
 
 
-# test_pitch_octave_value
+@pytest.mark.parametrize(
+    ("abc", "expected_value"),
+    [
+        ("^^B", 4),
+        ("^B", 4),
+        #
+        ("__C", 4),
+        ("_C", 4),
+    ],
+)
+def test_note_octave_value(abc, expected_value):
+    assert Note.from_abc(abc).octave == expected_value
 
 
 @pytest.mark.parametrize("p", ["C", "Dbb"])

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -1,6 +1,8 @@
 """
 Test the pitch and note modules
 """
+import warnings
+
 import pytest
 
 from pyabc2.key import Key
@@ -68,7 +70,9 @@ def test_pitch_value_acc_outside_octave(name, expected_value):
 def test_octave_value(name, expected_value):
     # Issue 17
     # https://en.wikipedia.org/wiki/Scientific_pitch_notation#Nomenclature
-    assert Pitch.from_name(name).octave == expected_value
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="computed pitch class value outside 0--11")
+        assert Pitch.from_name(name).octave == expected_value
 
 
 @pytest.mark.parametrize("p", ["C", "Dbb"])

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -42,11 +42,33 @@ def test_pitch_value(name, expected_value):
     ],
 )
 def test_pitch_value_acc_outside_octave(name, expected_value):
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match="computed pitch class value outside 0--11"):
         value = pitch_class_value(name)
     assert value == expected_value
 
     pitch_class_value(name, mod=True)  # no warning
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_value"),
+    [
+        ("Bbb3", 3),
+        ("Bb3", 3),
+        ("B3", 3),
+        ("B#3", 3),
+        ("B##3", 3),
+        #
+        ("Cbb4", 4),
+        ("Cb4", 4),
+        ("C4", 4),
+        ("C#4", 4),
+        ("C##4", 4),
+    ],
+)
+def test_octave_value(name, expected_value):
+    # Issue 17
+    # https://en.wikipedia.org/wiki/Scientific_pitch_notation#Nomenclature
+    assert Pitch.from_name(name).octave == expected_value
 
 
 @pytest.mark.parametrize("p", ["C", "Dbb"])


### PR DESCRIPTION
Closes #17 

Here we use the same approach as used to ensure that pitch class name remains consistent: optional attr that we use if set but otherwise use the pitch `.value`.