### PR TITLE
Fix `Note` to/from ABC with key used

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI workflow status](https://github.com/zmoon/PyABC2/actions/workflows/ci.yml/badge.svg)](https://github.com/zmoon/PyABC2/actions/workflows/ci.yml)
 [![Test coverage](https://codecov.io/gh/zmoon/PyABC2/branch/main/graph/badge.svg)](https://app.codecov.io/gh/zmoon/PyABC2)
 
-![image](https://user-images.githubusercontent.com/15079414/135684293-0cb815bd-c41f-4bc1-91b0-a30f8c3f6757.png)
+![image](https://user-images.githubusercontent.com/15079414/195207144-83df651a-6fe9-44b1-b7bc-e4aced14a2aa.png)
 
 ## Credits
 

--- a/pyabc2/note.py
+++ b/pyabc2/note.py
@@ -183,7 +183,8 @@ class Note(Pitch):
             relative_duration = Fraction(num) if num is not None else Fraction(1)
 
         note = cls(value, relative_duration * unit_duration)
-        note._class_name = nat_class_name + acc_ascii
+        if acc_marks is not None:
+            note._class_name = nat_class_name + acc_ascii
         note._octave = octave
 
         return note

--- a/pyabc2/note.py
+++ b/pyabc2/note.py
@@ -210,7 +210,10 @@ class Note(Pitch):
             raise NotImplementedError(f"note name longer than 2 chars {note_name!r}")
 
         # Adjust for key sig
-        if acc and note_nat in key.accidentals:
+        assert acc in {"", "^", "_", "="}
+        if acc in {"^", "_"} and note_nat in key.accidentals:
+            acc = ""
+        if acc == "=" and note_nat in [str(pc) for pc in key.scale]:
             acc = ""
 
         # Lowercase letter if in 2nd octave or more

--- a/pyabc2/parse.py
+++ b/pyabc2/parse.py
@@ -284,7 +284,7 @@ class Tune:
                         if m_note is None:
                             raise ValueError(f"no notes in this note group? {note_group!r}")
 
-                        measure.append(Note._from_abc_match(m_note))
+                        measure.append(Note._from_abc_match(m_note, key=self.key))
 
                 measures.append(measure)
 

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -266,6 +266,25 @@ def test_note_to_from_abc_consistency():
     assert Note.from_abc(n.to_abc(key=Key("C#")), key=Key("C#")) == n
 
 
+def test_note_issue27():
+    Gmaj = Key("G")
+
+    # If no accidental set, still display as F# (from default acc)
+    n = Note.from_abc("F", key=Gmaj)
+    assert n.value == Pitch.from_name("F#4").value, "value depends on key"
+    assert n.class_name == "F#"
+    assert str(n) == "F#4_1/8"
+    assert n.to_abc() == "^F", "default key is C, F# is not in the scale"
+    assert n.to_abc(key=Gmaj) == "F"
+
+    # When accidental is set, store
+    n = Note.from_abc("=F", key=Gmaj)
+    assert n.value == Pitch.from_name("F4").value
+    assert n.class_name == "F="
+    assert str(n) == "F=4_1/8"
+    # assert n.to_abc() == "F", "default key is C, F= is in the scale"
+
+
 @pytest.mark.parametrize(
     ("v", "expected_name"),
     [

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -2,11 +2,12 @@
 Test the pitch and note modules
 """
 import warnings
+from functools import partial
 
 import pytest
 
 from pyabc2.key import Key
-from pyabc2.note import Note
+from pyabc2.note import Note, _octave_from_abc_parts
 from pyabc2.pitch import (
     Pitch,
     PitchClass,
@@ -532,3 +533,26 @@ def test_note_to_from_nonimpl(meth):
     assert hasattr(Note, meth)
     with pytest.raises(NotImplementedError):
         getattr(Note, meth)()
+
+
+@pytest.mark.parametrize(
+    "note,oct,expected",
+    [
+        ("C", None, 0),
+        ("c", None, 1),
+        ("C", "", 0),
+        ("c", "", 1),
+        ("C", "'", 1),
+        ("c", "'", 2),
+        ("c", "''", 3),
+        ("C", ",", -1),
+        ("C", ",,", -2),
+        # Would be unusual:
+        ("C", ",'", 0),
+        ("C", ",','", 0),
+        ("C", ",,''", 0),
+    ],
+)
+def test_abc_doctave_calc(note, oct, expected):
+    fn = partial(_octave_from_abc_parts, base=0)
+    assert fn(note, oct) == expected

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -282,7 +282,8 @@ def test_note_issue27():
     assert n.value == Pitch.from_name("F4").value
     assert n.class_name == "F="
     assert str(n) == "F=4_1/8"
-    # assert n.to_abc() == "F", "default key is C, F= is in the scale"
+    assert n.to_abc() == "F", "default key is C, F= is in the scale"
+    assert n.to_abc(key=Gmaj) == "=F", "F= is not in Gmaj scale"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -275,7 +275,7 @@ def test_note_issue27():
     assert n.class_name == "F#"
     assert str(n) == "F#4_1/8"
     assert n.to_abc() == "^F", "default key is C, F# is not in the scale"
-    assert n.to_abc(key=Gmaj) == "F"
+    assert n.to_abc(key=Gmaj) == "F", "F# is in the Gmaj scale"
 
     # When accidental is set, store
     n = Note.from_abc("=F", key=Gmaj)
@@ -284,6 +284,27 @@ def test_note_issue27():
     assert str(n) == "F=4_1/8"
     assert n.to_abc() == "F", "default key is C, F= is in the scale"
     assert n.to_abc(key=Gmaj) == "=F", "F= is not in Gmaj scale"
+
+    # Note.to_* methods
+    n = Note.from_abc("c", key=Key("Dmaj"))
+    n2 = Note.from_abc("^c", key=Key("Dmaj"))
+    p = Pitch.from_name("C#5")
+    pc = PitchClass.from_name("C#")
+    assert n.value == n2.value == p.value
+    p_n = n.to_pitch()
+    p_n2 = n2.to_pitch()
+    assert p_n == p_n2 == p
+    assert str(p_n) == str(p_n2) == str(p) == "C#5"
+    pc_n = n.to_pitch_class()
+    pc_n2 = n.to_pitch_class()
+    assert (
+        str(pc_n)
+        == str(pc_n2)
+        == str(p_n.to_pitch_class())
+        == str(p_n2.to_pitch_class())
+        == str(pc)
+        == "C#"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* be sure to pass `key` when creating `Note` objects for `Tune` when parsing ABC
  - and update the readme polar plot (can't believe I didn't notice it was showing Fnat instead of F#...)
* fix some `Note` reprs (`value`s were mostly ok, but reprs not consistent with pitch)

Resolves #27 