### PR TITLE
Add support for The Session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest -v --cov=pyabc2 --cov-report xml
+          pytest -v --cov=pyabc2 --cov-report xml -n auto
 
       - name: Check type annotations
         run: |

--- a/examples/sources.ipynb
+++ b/examples/sources.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d8d66c8-5542-4813-ac72-b7bd6a171ad1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyabc2.sources import the_session, norbeck"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f9879cd-40c1-4189-9dbe-aedecab3929d",
+   "metadata": {},
+   "source": [
+    "## Norbeck"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da2e44fa-e6d7-4705-a8e6-71cfa43f8a9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tunes = norbeck.load(\"jigs\")\n",
+    "tunes[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a1ebb56-dfb3-49d7-84e9-68d4bf4d2c2f",
+   "metadata": {},
+   "source": [
+    "## The Session"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a73fd0b9-0c27-4b3f-bfb1-66dcfde656f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tune = the_session.load_url(\"https://thesession.org/tunes/21799#setting43712\")\n",
+    "tune"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2322e124-5f5a-46f5-b77f-aca1fd28e326",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tune.print_measures()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyabc2/_util.py
+++ b/pyabc2/_util.py
@@ -1,0 +1,19 @@
+"""Internal utilities."""
+
+import logging
+import sys
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get logger, with fancy format and configured for stdout."""
+
+    logger = logging.getLogger(name)
+    sh = logging.StreamHandler(sys.stdout)
+    f = logging.Formatter(
+        "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
+        datefmt=r"%d-%b-%Y %H:%M:%S",
+    )
+    sh.setFormatter(f)
+    logger.addHandler(sh)
+
+    return logger

--- a/pyabc2/parse.py
+++ b/pyabc2/parse.py
@@ -307,6 +307,16 @@ class Tune:
             f"{self.__class__.__name__}(title={self.title!r}, key={self.key}, type={self.type!r})"
         )
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        # TODO: really would want to check _equivalent_ abc; need some normalization
+        return other.abc == self.abc
+
+    def __hash__(self):
+        return hash(self.abc)
+
     def _repr_html_(self):
         import uuid
 

--- a/pyabc2/parse.py
+++ b/pyabc2/parse.py
@@ -328,10 +328,10 @@ class Tune:
         js = Javascript(_FMT_ABCJS_RENDER_JS.format(abc=abc, notation_id=notation_id))
         display(js)
 
-    def print_measures(self, *, note_format: str = "ABC"):
+    def print_measures(self, n: Optional[int] = None, *, note_format: str = "ABC"):
         """Print measures to check parsing."""
         nd = len(str(len(self.measures)))
-        for i, measure in enumerate(self.measures, start=1):
+        for i, measure in enumerate(self.measures[:n], start=1):
             if note_format == "ABC":
                 print(f"{i:0{nd}d}: {' '.join(n.to_abc(key=self.key) for n in measure)}")
             else:

--- a/pyabc2/parse.py
+++ b/pyabc2/parse.py
@@ -164,6 +164,30 @@ def _load_abcjs_if_in_jupyter() -> None:
         print("abcjs loaded")
 
 
+def _find_first_chord(s: str) -> Optional[str]:
+    """Search for first chord spec in an ABC body portion.
+
+    https://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons
+    """
+    from .note import _S_RE_NOTE
+
+    # `{2,}` (2 or more) doesn't seem to work,
+    # so we look for one or more and then count notes after
+    m = re.search(rf"\[({_S_RE_NOTE})+\]", s)
+    if m is None:
+        return None
+
+    # Here, we have a potential chord (may only have one note, which we want to reject)
+    # NOTE: did see some single notes inside `[]` in The Session data
+    c = m.group()
+    assert c.startswith("[") and c.endswith("]")
+    n = len(_RE_NOTE.findall(c))  # TODO: maybe just letter count would be suff.
+    if n >= 2:
+        return c
+    else:
+        return None
+
+
 # TODO: maybe should go in a tune module
 class Tune:
     """Tune."""
@@ -247,12 +271,26 @@ class Tune:
         measures = []
         for line in tune_lines:
 
+            # Check for chords (not currently supporting)
+            # https://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons
+            # TODO: replace chords by one of the notes?
+            first_chord = _find_first_chord(line)
+            has_chord = first_chord is not None
+            if has_chord:
+                raise ValueError(
+                    "chords currently not supported, " f"but found {first_chord!r} in line {line!r}"
+                )
+
             if line.startswith("|:"):
                 # Left repeat detected -- new starting measure for a repeated section
                 i_measure_repeat = i_measure
 
             # 1. In line, find measures
             for m_measure in re.finditer(r"([^\|\:\]]+)(\:?\|+\:?)", line):
+                # TODO: breaks up measures that use general tuplet syntax (with `:`)
+                # https://abcnotation.com/wiki/abc:standard:v2.1#duplets_triplets_quadruplets_etc
+                # TODO: within-line meter changes (e.g. `|M:3/2 ...`) also have `:`
+                # Maybe could just remove `:` from the the search and lstrip it from `within_measure`
                 within_measure, right_sep = m_measure.groups()
 
                 if right_sep.endswith(":"):
@@ -262,14 +300,25 @@ class Tune:
                 if within_measure.startswith(("1", "[1", " [1")):
                     i_ending = i_measure
 
+                # TODO: other specs can indicate more than 2 endings (comma-sep list and range notations)
+                # https://abcnotation.com/wiki/abc:standard:v2.1#variant_endings
                 if within_measure.startswith(("3", "[3", " [3")):
-                    raise ValueError("3 or more endings not currently supported")
+                    # NOTE: can catch incorrect triplet `3(ABC)` at start of measure
+                    # Also have seen `3ABC` at start of tune or line
+                    # Triplets should be written like `(3ABC` (no closing paren)
+                    # https://abcnotation.com/wiki/abc:standard:v2.1#duplets_triplets_quadruplets_etc
+                    # Could look for these cases and fix them?
+                    raise ValueError(
+                        "3 or more endings not currently supported, "
+                        f"but measure {within_measure!r} starts with one of {'3', '[3', ' [3'}, "
+                        f"found in line {line!r}"
+                    )
 
                 # TODO: check for inline meter change; validate measure beat count?
 
                 measure = []
 
-                # 2. In measure, find note groups
+                # 2. In measure, find note groups ("beams")
                 # Currently not doing anything with note group, but may want to in the future
                 for note_group in within_measure.split(" "):
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -667,13 +667,13 @@ class Pitch:
 
 # https://en.wikipedia.org/wiki/File:Main_intervals_from_C.png
 MAIN_INTERVAL_SHORT_NAMES = [
-    "P1",
+    "P1",  # aka "U"
     "m2",
     "M2",
     "m3",
     "M3",
     "P4",
-    "A4",
+    "A4",  # aka "TT"
     "P5",
     "m6",
     "M6",
@@ -710,6 +710,7 @@ class SimpleInterval:
     def name(self) -> str:
         """Major, minor, or perfect interval short name."""
         return MAIN_INTERVAL_SHORT_NAMES[self.value]
+        # TODO: based on context https://en.wikipedia.org/wiki/Interval_(music)#Main_intervals
 
     @property
     def whole_steps(self) -> float:
@@ -758,6 +759,8 @@ class SignedInterval(SimpleInterval):
         is_neg = self.value < 0
 
         n_o, i0 = divmod(abs(self.value), 12)
+
+        # TODO: https://en.wikipedia.org/wiki/Interval_(music)#Main_compound_intervals
 
         if n_o >= 2:
             s_o = f"{n_o}({MAIN_INTERVAL_SHORT_NAMES[-1]})"

--- a/pyabc2/sources/__init__.py
+++ b/pyabc2/sources/__init__.py
@@ -47,8 +47,11 @@ def load_example_abc(title: Optional[str] = None) -> str:
     abc = examples.get(k)
 
     if abc is None:
-        example_list = "\n".join(f"  {t!r}" for t in examples)
-        raise ValueError("invalid tune title. Valid options are:\n" f"{example_list}")
+        example_list = "\n".join(f"  - {t!r}" for t in examples)
+        raise ValueError(
+            f"invalid tune title {title!r}. "
+            f"Valid options are (case-insensitive):\n{example_list}"
+        )
 
     return abc
 

--- a/pyabc2/sources/__init__.py
+++ b/pyabc2/sources/__init__.py
@@ -58,7 +58,7 @@ def load_example(title: Optional[str] = None) -> Tune:
     random if `title` not provided.
     Case ignored in the title.
     """
-    return Tune(load_example_abc())
+    return Tune(load_example_abc(title))
 
 
 def load_url(url: str) -> Tune:

--- a/pyabc2/sources/__init__.py
+++ b/pyabc2/sources/__init__.py
@@ -59,3 +59,23 @@ def load_example(title: Optional[str] = None) -> Tune:
     Case ignored in the title.
     """
     return Tune(load_example_abc())
+
+
+def load_url(url: str) -> Tune:
+    """Load tune from ABC corresponding to `url`.
+
+    Currently these URL types are supported:
+    - Norbeck (``norbeck.nu/abc/``)
+    - The Session (``thesession.org``)
+    """
+    from urllib.parse import urlsplit
+
+    from . import norbeck, the_session
+
+    res = urlsplit(url)
+    if res.netloc in norbeck._URL_NETLOCS:
+        return norbeck.load_url(url)
+    elif res.netloc in the_session._URL_NETLOCS:
+        return the_session.load_url(url)
+    else:
+        raise NotImplementedError("loading URL from {res.netloc} not implemented.")

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -45,7 +45,7 @@ def download() -> None:
 
     try:
         r.raise_for_status()
-    except requests.exceptions.HTTPError as e:
+    except requests.exceptions.HTTPError as e:  # pragma: no cover
         raise Exception("Norbeck file unable to be downloaded (check URL).") from e
 
     SAVE_TO.mkdir(exist_ok=True)
@@ -139,7 +139,7 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
     for abc0 in blocks:
         try:
             tunes.append(Tune(_replace_escaped_diacritics(abc0, ascii_only=ascii_only)))
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             raise Exception(f"loading this ABC:\n---\n{abc0}\n---\nfailed") from e
 
     # Add norbeck.nu/abc/ URLs
@@ -227,7 +227,7 @@ def load_url(url: str) -> Tune:
     return Tune(abc)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     tune = load_url("https://norbeck.nu/abc/display.asp?rhythm=slip+jig&ref=106")
     print(tune.title)
     tune.print_measures(5)

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -12,6 +12,25 @@ HERE = Path(__file__).parent
 
 SAVE_TO = HERE / "_norbeck"
 
+_TYPE_PREFIX = {
+    "reels": "hnr",
+    "jigs": "hnj",
+    "hornpipes": "hnhp",
+    "polkas": "hnp",
+    "slip jigs": "hnsj",
+}
+
+# https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes
+_COMBINING_ACCENT_FROM_ASCII_SYM = {
+    "`": "\u0300",  # grave
+    "'": "\u0301",  # acute
+    "^": "\u0302",  # circumflex
+    '"': "\u0308",  # umlaut
+    "r": "\u030A",  # ring above
+}
+
+_URL_NETLOCS = {"norbeck.nu", "www.norbeck.nu"}
+
 
 def download() -> None:
     import io
@@ -40,29 +59,10 @@ def download() -> None:
                     f.write(zf.read())
 
 
-_TYPE_PREFIX = {
-    "reels": "hnr",
-    "jigs": "hnj",
-    "hornpipes": "hnhp",
-    "polkas": "hnp",
-    "slip jigs": "hnsj",
-}
-
-
 def _maybe_download() -> None:
     if not list(SAVE_TO.glob("*.abc")):
         print("downloading missing files...")
         download()
-
-
-# https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes
-_COMBINING_ACCENT_FROM_ASCII_SYM = {
-    "`": "\u0300",  # grave
-    "'": "\u0301",  # acute
-    "^": "\u0302",  # circumflex
-    '"': "\u0308",  # umlaut
-    "r": "\u030A",  # ring above
-}
 
 
 def _replace_escaped_diacritics(abc: str, *, ascii_only: bool = False) -> str:
@@ -152,6 +152,9 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
     return tunes
 
 
+# TODO: pre-process to json?
+
+
 def load(which: Union[str, List[str]] = "all", *, ascii_only: bool = False) -> List[Tune]:
     """
     Load a list of tunes, by type(s) or all of them.
@@ -209,7 +212,7 @@ def load_url(url: str) -> Tune:
     import requests
 
     res = urlsplit(url)
-    assert res.netloc in {"norbeck.nu", "www.norbeck.nu"}
+    assert res.netloc in _URL_NETLOCS
     assert res.path.startswith("/abc")
 
     r = requests.get(urlunsplit(res._replace(scheme="https")))

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -224,8 +224,11 @@ def load_url(url: str, *, ascii_only: bool = False) -> Tune:
 
 if __name__ == "__main__":
     tune = load_url("https://norbeck.nu/abc/display.asp?rhythm=slip+jig&ref=106")
+    print(tune.title)
     tune.print_measures(5)
 
     tune = load_url("https://www.norbeck.nu/abc/display.asp?rhythm=sl%C3%A4ngpolska&ref=8")
+    print()
+    print(tune.title)
     tune.print_measures(5)
     print(tune.abc)

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -199,6 +199,8 @@ def load_url(url: str) -> Tune:
     For example:
     - https://norbeck.nu/abc/display.asp?rhythm=slip+jig&ref=106
     - https://www.norbeck.nu/abc/display.asp?rhythm=reel&ref=693
+
+    Grabs the ABC from the HTML source.
     """
     import re
     from html import unescape

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -175,7 +175,9 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
         warnings.warn(msg)
 
     if expected_failures:
-        logger.debug(f"{len(expected_failures)} expected failure(s): {expected_failures}")
+        logger.debug(
+            f"{len(expected_failures)} expected failure(s) in file {fp.name}: {expected_failures}"
+        )
 
     # Add norbeck.nu/abc/ URLs
     for tune in tunes:

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -149,18 +149,18 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
     blocks = []
     with open(fp, "r") as f:
 
-        block = ""
-        iblock = -1
+        block = None
         add = False
-        in_header = True
 
         for line in f:
             if line.startswith("X:"):
+                # Add (if not first X)
+                if block is not None:
+                    blocks.append(block.strip())
+
                 # New tune, reset
                 block = line
-                iblock += 1
                 add = True
-                in_header = False
                 continue
 
             if line.startswith("P:"):
@@ -170,11 +170,9 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
             if add:
                 block += line
 
-            if line.strip() == "" and not in_header:
-                # Between tune blocks, save
-                block = block.strip()
-                if not blocks or blocks[-1] != block:
-                    blocks.append(block)
+        # Add last block
+        if block is not None:
+            blocks.append(block.strip())
 
     tunes: List[Tune] = []
     failed: int = 0

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -65,7 +65,7 @@ _COMBINING_ACCENT_FROM_ASCII_SYM = {
 }
 
 
-def _abc_to_tune(abc: str, *, ascii_only: bool = False) -> Tune:
+def _replace_escaped_diacritics(abc: str, *, ascii_only: bool = False) -> str:
     """Load a Norbeck ABC, dealing with LaTeX-style diacritic escape codes."""
     import re
 
@@ -101,7 +101,7 @@ def _abc_to_tune(abc: str, *, ascii_only: bool = False) -> Tune:
 
         abc2 = abc2.replace(s, snew)
 
-    return Tune(abc2)
+    return abc2
 
 
 def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
@@ -138,7 +138,7 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
     tunes: List[Tune] = []
     for abc0 in blocks:
         try:
-            tunes.append(_abc_to_tune(abc0, ascii_only=ascii_only))
+            tunes.append(Tune(_replace_escaped_diacritics(abc0, ascii_only=ascii_only)))
         except Exception as e:
             raise Exception(f"loading this ABC:\n---\n{abc0}\n---\nfailed") from e
 
@@ -193,7 +193,7 @@ def load(which: Union[str, List[str]] = "all", *, ascii_only: bool = False) -> L
     return tunes
 
 
-def load_url(url: str, *, ascii_only: bool = False) -> Tune:
+def load_url(url: str) -> Tune:
     """Load tune from a specified ``norbeck.nu/abc/`` URL.
 
     For example:
@@ -219,7 +219,7 @@ def load_url(url: str, *, ascii_only: bool = False) -> Tune:
     assert m is not None
     abc = unescape(m.group(1)).replace("<br/>", "")
 
-    return _abc_to_tune(abc, ascii_only=ascii_only)
+    return Tune(abc)
 
 
 if __name__ == "__main__":

--- a/pyabc2/sources/norbeck.py
+++ b/pyabc2/sources/norbeck.py
@@ -168,6 +168,7 @@ def _load_one_file(fp: Path, *, ascii_only: bool = False) -> List[Tune]:
                 add = False
 
             if add:
+                assert block is not None
                 block += line
 
         # Add last block

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -283,6 +283,7 @@ def load_meta(
     if format == "json":
         df = pd.read_json(url)
     else:
+        parse_dates: Union[bool, List[str]]
         if which in {"sets", "sessions", "tunes"}:
             parse_dates = ["date"]
         elif which in {"events"}:

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 from ..parse import Tune
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import pandas
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ def load_url(url: str) -> Tune:
         for d in data["settings"]:
             if d["id"] == setting:
                 break
-        else:
+        else:  # pragma: no cover
             raise ValueError(f"detected setting {setting} not found in {to_query}")
 
     # Add non-setting-specific data
@@ -146,7 +146,7 @@ def _maybe_load_one(d: dict) -> Optional[Tune]:
 
     try:
         tune = _data_to_tune(d)
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         d_ = {k: v for k, v in d.items() if k in {"tune_id", "setting_id", "title"}}
         abc_ = indent(d["abc"], " ")
         logger.debug(f"Failed to load ({e}): {d_}\n{abc_}")
@@ -170,7 +170,7 @@ def load(
     fp = SAVE_TO / "tunes.json"
     parallel = num_workers > 1
 
-    if debug:
+    if debug:  # pragma: no cover
         logger.setLevel(logging.DEBUG)
     else:
         logger.setLevel(logging.NOTSET)
@@ -342,7 +342,7 @@ def load_meta(
     return df
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     tune = load_url("https://thesession.org/tunes/10000")
     print(tune)
     tune.print_measures(4)

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -291,16 +291,7 @@ def load_meta(
         pass
 
     elif which == "sessions":
-        # Workaround for https://github.com/adactio/TheSession-data/issues/15
-        assert df.latitude.dtype == np.float64
-        assert df.longitude.dtype == np.dtype("O")
-        is_bad = df.longitude.str.len() == 19
-        bad = df[is_bad]
-        if not bad.empty:
-            warnings.warn(f"{len(bad)} bad lon rows found in {which}, fixing")
-        df.loc[is_bad, "date"] = pd.to_datetime(bad.longitude)
-        df.loc[is_bad, "longitude"] = np.nan
-        df["longitude"] = df.longitude.astype(float)
+        pass
 
     elif which == "sets":
         # int cols: 'tuneset', 'member_id', 'settingorder', 'tune_id', 'setting_id'

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -143,13 +143,13 @@ def load() -> List[Tune]:
 if __name__ == "__main__":
     tune = load_url("https://thesession.org/tunes/10000")
     print(tune)
-    tune.print_measures()
+    tune.print_measures(4)
 
     tune = load_url("https://thesession.org/tunes/10000#31601")
     print(tune)
-    tune.print_measures()
+    tune.print_measures(5)
 
     tunes = load()
     for tune in tunes[:2]:
         print(tune)
-        tune.print_measures()
+        tune.print_measures(4)

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -121,7 +121,7 @@ def download(which: Union[str, List[str]] = "tunes") -> None:
             f.write(r.content)
 
 
-def load() -> List[Tune]:
+def load(*, n: Optional[int] = None) -> List[Tune]:
     """Load tunes from https://github.com/adactio/TheSession-data
 
     @adactio (Jeremy) is the creator of The Session.
@@ -135,10 +135,7 @@ def load() -> List[Tune]:
     with open(fp, encoding="utf-8") as f:
         data = json.load(f)
 
-    print(len(data), "tune dicts in this data dump")
-    data = data[:5]
-    for d in data:
-        print(d)
+    data = data[:n]
 
     # TODO: multi-proc
     tunes = [_data_to_tune(d) for d in data]
@@ -155,7 +152,7 @@ if __name__ == "__main__":
     print(tune)
     tune.print_measures(5)
 
-    tunes = load()
+    tunes = load(n=5)
     for tune in tunes[:2]:
         print(tune)
         tune.print_measures(4)

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -187,7 +187,7 @@ def load(
     if parallel:
         import multiprocessing
 
-        if debug:
+        if debug:  # pragma: no cover
             warnings.warn("Multi-processing, detailed debug messages won't be shown.")
 
         with multiprocessing.Pool(num_workers) as pool:
@@ -247,7 +247,7 @@ def _choose_int_type(s, *, ext: bool = False):
     for max_, typ, ext_typ_str in to_try:
         if s_max <= max_:
             break
-    else:
+    else:  # pragma: no cover
         raise AssertionError("shouldn't reach here")
 
     return ext_typ_str if ext else typ
@@ -276,7 +276,7 @@ def load_meta(
     df = pd.read_json(url)
 
     cat_cols = []
-    if which == "ali":
+    if which == "aliases":
         pass
 
     elif which == "events":
@@ -317,7 +317,7 @@ def load_meta(
         # int cols: 'tune_id', 'setting_id'
         cat_cols = ["type", "meter", "mode"]
 
-    else:
+    else:  # pragma: no cover
         raise AssertionError("shouldn't reach here")
 
     if downcast_ints:

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -3,11 +3,11 @@ Load data from The Session (https://thesession.org)
 """
 import logging
 import os
-import sys
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
+from .._util import get_logger as _get_logger
 from ..parse import Tune
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -15,15 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _DEBUG_SHOW_FULL_ABC = os.getenv("PYABC_DEBUG_SHOW_FULL_ABC", False)
 
-logger = logging.getLogger(__name__)
-sh = logging.StreamHandler(sys.stdout)
-f = logging.Formatter(
-    "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
-    datefmt=r"%d-%b-%Y %H:%M:%S",
-)
-sh.setFormatter(f)
-logger.addHandler(sh)
-del f, sh
+logger = _get_logger(__name__)
 
 HERE = Path(__file__).parent
 
@@ -185,7 +177,7 @@ def _maybe_load_one(d: dict) -> Optional[Tune]:
         tune = _archive_data_to_tune(d)
     except Exception as e:  # pragma: no cover
         d_ = {k: v for k, v in d.items() if k in {"tune_id", "setting_id", "title"}}
-        msg = f"Failed to load ({e}): {d_}"
+        msg = f"Failed to load ABC ({e}): {d_}"
         if _DEBUG_SHOW_FULL_ABC:
             abc_ = indent(d["abc"], "  ")
             msg += f"\n{abc_}"

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -124,15 +124,19 @@ def download(which: Union[str, List[str]] = "tunes") -> None:
             f.write(r.content)
 
 
-def load(*, n: Optional[int] = None) -> List[Tune]:
+def load(*, n: Optional[int] = None, redownload: bool = False) -> List[Tune]:
     """Load tunes from https://github.com/adactio/TheSession-data
+
+    Use ``redownload=True`` to force re-download. Otherwise the file will only
+    be downloaded if it hasn't already been.
 
     @adactio (Jeremy) is the creator of The Session.
     """
     import json
 
     fp = SAVE_TO / "tunes.json"
-    if not fp.is_file():
+
+    if not fp.is_file() or redownload:
         download("tunes")
 
     with open(fp, encoding="utf-8") as f:

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -1,0 +1,63 @@
+"""
+Load data from The Session (https://thesession.org)
+"""
+from pathlib import Path
+
+from ..parse import Tune
+
+
+def load_url(url: str) -> Tune:
+    """Load tune from a specified ``thesession.org`` URL.
+
+    For example:
+    - https://thesession.org/tunes/10000 (first setting assumed)
+    - https://thesession.org/tunes/10000#setting31601 (specific setting)
+
+    Using the API: https://thesession.org/api
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    import requests
+
+    res = urlsplit(url)
+    if res.fragment:
+        setting = res.fragment
+    else:
+        setting = Path(res.path).name
+    setting = int(setting)
+    to_query = urlunsplit(res._replace(scheme="https", fragment="", query="format=json"))
+
+    r = requests.get(to_query)
+    r.raise_for_status()
+    data = r.json()
+
+    for d in data["settings"]:
+        if d["id"] == setting:
+            break
+    else:
+        raise Exception(f"setting {setting} not found in {to_query}")
+
+    name = data["name"]
+    type_ = data["type"]  # e.g. 'reel'
+    melody_abc = d["abc"]
+    key = d["key"]
+    # TODO: provide guess for M? (based on type)
+
+    abc = f"""\
+T:{name}
+R:{type_}
+K:{key}
+{melody_abc}
+"""
+
+    return Tune(abc)
+
+
+if __name__ == "__main__":
+    tune = load_url("https://thesession.org/tunes/10000")
+    print(tune)
+    tune.print_measures()
+
+    tune = load_url("https://thesession.org/tunes/10000#31601")
+    print(tune)
+    tune.print_measures()

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -262,9 +262,16 @@ def load_meta(
 ) -> "pandas.DataFrame":
     """Load metadata file from The Session archive as dataframe (requires pandas).
 
-    Note: in string columns (dtype ``object``), missing value is ``''`` (empty string).
+    In string columns (dtype ``object``), missing value is ``''`` (empty string)
+    and is currently left that way by default.
+    However, if ``convert_dtypes=True`` is used, this will be set to null,
+    and dtypes converted to nullable pandas extension types
+    (:meth:`pandas.DataFrame.convert_dtypes` applied).
 
     https://github.com/adactio/TheSession-data/tree/main/json
+    https://github.com/adactio/TheSession-data/tree/main/csv
+
+    @adactio (Jeremy) is the creator of The Session.
     """
     import numpy as np
     import pandas as pd

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -25,6 +25,10 @@ _TYPE_TO_METER = {
     "march": "4/4",
 }
 
+_URL_NETLOCS = {
+    "thesession.org",
+}
+
 
 def _data_to_tune(data):
     name = data["name"]
@@ -60,7 +64,7 @@ def load_url(url: str) -> Tune:
     import requests
 
     res = urlsplit(url)
-    assert res.netloc == "thesession.org"
+    assert res.netloc in _URL_NETLOCS
     setting: Optional[int]
     if res.fragment:
         setting_str = res.fragment
@@ -162,7 +166,7 @@ if __name__ == "__main__":
     print(tune)
     tune.print_measures(5)
 
-    tunes = load(n=5)
-    for tune in tunes[:2]:
+    tunes = load(n=3)
+    for tune in tunes:
         print(tune)
         tune.print_measures(4)

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -5,9 +5,12 @@ import logging
 import sys
 import warnings
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from ..parse import Tune
+
+if TYPE_CHECKING:
+    import pandas
 
 logger = logging.getLogger(__name__)
 sh = logging.StreamHandler(sys.stdout)
@@ -136,7 +139,7 @@ def download(which: Union[str, List[str]] = "tunes") -> None:
             f.write(r.content)
 
 
-def _maybe_load_one(d: dict) -> Tune:
+def _maybe_load_one(d: dict) -> Optional[Tune]:
     """Try to load tune from a The Session data entry, otherwise log debug messages
     and return None."""
     from textwrap import indent
@@ -250,7 +253,9 @@ def _choose_int_type(s, *, ext: bool = False):
     return ext_typ_str if ext else typ
 
 
-def load_meta(which: str, *, convert_dtypes: bool = False, downcast_ints: bool = False):
+def load_meta(
+    which: str, *, convert_dtypes: bool = False, downcast_ints: bool = False
+) -> "pandas.DataFrame":
     """Load metadata file from The Session archive as dataframe (requires pandas).
 
     Note: in string columns (dtype ``object``), missing value is ``''`` (empty string).
@@ -304,6 +309,8 @@ def load_meta(which: str, *, convert_dtypes: bool = False, downcast_ints: bool =
     elif which == "tune_popularity":
         # str cols: 'name', 'tunebooks'
         # int cols: 'tune_id'
+        # Currently min tunebook count ('tunebooks') is 10
+        # (https://github.com/adactio/TheSession-data/issues/14)
         pass
 
     elif which == "tunes":

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -5,6 +5,21 @@ from pathlib import Path
 
 from ..parse import Tune
 
+_TYPES = {
+    "jig": (),
+    "reel": (),
+    "slip jig": (),
+    "hornpipe": (),
+    "polka": (),
+    "slide": (),
+    "waltz": (),
+    "barndance": (),
+    "strathspey": (),
+    "three-two": (),
+    "mazurka": (),
+    "march": (),
+}
+
 
 def load_url(url: str) -> Tune:
     """Load tune from a specified ``thesession.org`` URL.

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -2,7 +2,7 @@
 Load data from The Session (https://thesession.org)
 """
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from ..parse import Tune
 
@@ -62,11 +62,12 @@ def load_url(url: str) -> Tune:
 
     res = urlsplit(url)
     assert res.netloc == "thesession.org"
+    setting: Optional[int]
     if res.fragment:
-        setting = res.fragment
-        if setting.startswith("setting"):
-            setting = setting[len("setting") :]
-        setting = int(setting)
+        setting_str = res.fragment
+        if setting_str.startswith("setting"):
+            setting_str = setting_str[len("setting") :]
+        setting = int(setting_str)
     else:
         setting = None
     to_query = urlunsplit(res._replace(scheme="https", fragment="", query="format=json"))

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -30,7 +30,6 @@ def _data_to_tune(data):
     name = data["name"]
     type_ = data["type"]  # e.g. 'reel'
     melody_abc = data["abc"].replace("! ", "\n")
-    assert "!" not in melody_abc
     key = data["mode"]
     meter = data["meter"]
     unit_length = "1/8"
@@ -138,7 +137,18 @@ def load(*, n: Optional[int] = None) -> List[Tune]:
     data = data[:n]
 
     # TODO: multi-proc
-    tunes = [_data_to_tune(d) for d in data]
+    # tunes = [_data_to_tune(d) for d in data]
+    tunes = []
+    failed = 0
+    for d in data:
+        try:
+            tune = _data_to_tune(d)
+        except Exception:
+            failed += 1
+        else:
+            tunes.append(tune)
+
+    print(failed, "failed")
 
     return tunes
 

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -48,7 +48,7 @@ def _data_to_tune(data: dict) -> Tune:
     """Load one tune from a The Session JSON archive entry."""
     name = data["name"]
     type_ = data["type"]  # e.g. 'reel'
-    melody_abc = data["abc"].replace("! ", "\n")
+    melody_abc = data["abc"].replace("! ", "\n")  # for web API data
     key = data["mode"]
     meter = data["meter"]
     unit_length = "1/8"
@@ -144,6 +144,7 @@ def _maybe_load_one(d: dict) -> Optional[Tune]:
     and return None."""
     from textwrap import indent
 
+    d["abc"] = d["abc"].replace("\r\n", "\n")
     try:
         tune = _data_to_tune(d)
     except Exception as e:  # pragma: no cover

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -120,6 +120,10 @@ def download(which: Union[str, List[str]] = "tunes") -> None:
 
 
 def load() -> List[Tune]:
+    """Load tunes from https://github.com/adactio/TheSession-data
+
+    @adactio (Jeremy) is the creator of The Session.
+    """
     import json
 
     fp = SAVE_TO / "tunes.json"

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -61,6 +61,7 @@ def load_url(url: str) -> Tune:
     import requests
 
     res = urlsplit(url)
+    assert res.netloc == "thesession.org"
     if res.fragment:
         setting = res.fragment
         if setting.startswith("setting"):

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -49,6 +49,7 @@ def _api_data_to_tune(data: dict) -> Tune:
     melody_abc = data["abc"].replace("! ", "\n")
 
     # 'x' - setting number (for a specific tune; not same as setting ID)
+    # note: tune data has 'aliases', could use to provide additional T's (or set `titles` after init)
     abc = f"""\
 X:{data['x']}
 T:{data['name']}

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -35,7 +35,7 @@ def load_url(url: str) -> Tune:
         if d["id"] == setting:
             break
     else:
-        raise Exception(f"setting {setting} not found in {to_query}")
+        raise ValueError(f"detected setting {setting} not found in {to_query}")
 
     name = data["name"]
     type_ = data["type"]  # e.g. 'reel'

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -38,9 +38,7 @@ _TYPE_TO_METER = {
     "march": "4/4",
 }
 
-_URL_NETLOCS = {
-    "thesession.org",
-}
+_URL_NETLOCS = {"thesession.org"}
 
 
 def _data_to_tune(data: dict) -> Tune:
@@ -127,7 +125,7 @@ def download(which: Union[str, List[str]] = "tunes") -> None:
     supported = ["tunes"]
 
     if not set(which) <= set(supported):
-        raise ValueError(f"invalid `which`. Only these are supported: {supported}")
+        raise ValueError(f"invalid `which`. Only these are supported: {supported}.")
 
     for fstem in which:  # TODO: threaded
         fn = f"{fstem}.json"
@@ -209,6 +207,26 @@ def load(
         warnings.warn(msg)
 
     return tunes
+
+
+def load_meta(which: str):
+    """Load metadata file from The Session archive as dataframe (requires pandas).
+
+    https://github.com/adactio/TheSession-data/tree/main/json
+    """
+    import pandas as pd
+
+    allowed = ["aliases", "events", "recordings", "sessions", "sets", "tune_popularity", "tunes"]
+    if which not in allowed:
+        raise ValueError(f"invalid `which`. Valid choices: {allowed}.")
+
+    base_url = "https://raw.githubusercontent.com/adactio/TheSession-data/main/json/"
+    fn = f"{which}.json"
+    url = base_url + fn
+
+    df = pd.read_json(url)
+
+    return df
 
 
 if __name__ == "__main__":

--- a/pyabc2/sources/the_session.py
+++ b/pyabc2/sources/the_session.py
@@ -5,19 +5,19 @@ from pathlib import Path
 
 from ..parse import Tune
 
-_TYPES = {
-    "jig": (),
-    "reel": (),
-    "slip jig": (),
-    "hornpipe": (),
-    "polka": (),
-    "slide": (),
-    "waltz": (),
-    "barndance": (),
-    "strathspey": (),
-    "three-two": (),
-    "mazurka": (),
-    "march": (),
+_TYPE_TO_METER = {
+    "jig": "6/8",
+    "reel": "4/4",
+    "slip jig": "9/8",
+    "hornpipe": "4/4",
+    "polka": "2/4",
+    "slide": "12/8",
+    "waltz": "3/4",
+    "barndance": "4/4",
+    "strathspey": "4/4",
+    "three-two": "3/2",
+    "mazurka": "3/4",
+    "march": "4/4",
 }
 
 
@@ -56,11 +56,14 @@ def load_url(url: str) -> Tune:
     type_ = data["type"]  # e.g. 'reel'
     melody_abc = d["abc"]
     key = d["key"]
-    # TODO: provide guess for M? (based on type)
+    meter = _TYPE_TO_METER[type_]
+    unit_length = "1/8"
 
     abc = f"""\
 T:{name}
 R:{type_}
+M:{meter}
+L:{unit_length}
 K:{key}
 {melody_abc}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ test = [
     "pandas-stubs",
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
 ]
 dev = [
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,7 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 requires-python = "~=3.7"
-dependencies = [
-    "requests ~=2.0",
-]
+dependencies = []
 
 [project.urls]
 Home = "https://github.com/zmoon/PyABC2"
@@ -20,6 +18,10 @@ Source = "https://github.com/zmoon/PyABC2"
 # Documentation = ""
 
 [project.optional-dependencies]
+sources = [
+    "pandas",
+    "requests ~=2.0",
+]
 test = [
     "mypy",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ Source = "https://github.com/zmoon/PyABC2"
 
 [project.optional-dependencies]
 sources = [
+    "numpy",
     "pandas ~=1.4",
     "requests ~=2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 dependencies = []
 
 [project.urls]
@@ -19,7 +19,7 @@ Source = "https://github.com/zmoon/PyABC2"
 
 [project.optional-dependencies]
 sources = [
-    "pandas",
+    "pandas ~=1.4",
     "requests ~=2.0",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ sources = [
 ]
 test = [
     "mypy",
+    "pandas-stubs",
     "pytest",
     "pytest-cov",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,7 @@ line_length = 100
 
 [tool.pytest.ini_options]
 markers = ["slow"]
+
+[tool.mypy]
+exclude = ["^venv"]
+install_types = true

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 
 from pyabc2 import Key
@@ -87,18 +85,18 @@ def test_the_session_download_invalid():
     "which", ["aliases", "events", "recordings", "sessions", "sets", "tune_popularity", "tunes"]
 )
 def test_the_session_load_meta(which):
-    if which == "sessions":
-        ctx = pytest.warns(UserWarning, match="3 bad lon rows found")
-    else:
-        ctx = warnings.catch_warnings()
+    import numpy as np
 
-    with ctx:
-        df1 = the_session.load_meta(which)
-        df2 = the_session.load_meta(which, downcast_ints=True)
-        df3 = the_session.load_meta(which, convert_dtypes=True)
-        # assert df1.equals(df2)  # TODO
-        assert not (df2.dtypes == df1.dtypes).all()
-        assert not (df3.dtypes == df1.dtypes).all()
+    df1 = the_session.load_meta(which)
+    df2 = the_session.load_meta(which, downcast_ints=True)
+    df3 = the_session.load_meta(which, convert_dtypes=True)
+
+    # assert df1.equals(df2)  # TODO
+    assert not (df2.dtypes == df1.dtypes).all()
+    assert not (df3.dtypes == df1.dtypes).all()
+    if "latitude" in df1:
+        assert df1.latitude.dtype == np.float64
+        assert df1.longitude.dtype == np.float64
 
 
 def test_the_session_load_meta_invalid():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -85,7 +85,6 @@ def test_norbeck_x_vals():
 def test_norbeck_load():
     # NOTE: downloads files if not already present
 
-    # TODO: test Norbeck all matches number of `X:`s in those files
     tunes = norbeck.load()  # all
     jigs = norbeck.load("jigs")  # jigs only
     hps = norbeck.load("hornpipes")
@@ -94,8 +93,8 @@ def test_norbeck_load():
     assert "Pride of Petravore, The" not in set([t.title for t in tunes])
     assert "Pride of Petravore, The" not in set([t.title for t in hps])
 
-    # TODO: fix to base on expected duplicates and find the missing 1!
-    assert len(tunes) == NORBECK_IRISH_COUNT - 3
+    n_exp_fail = sum(len(lst) for d in norbeck._EXPECTED_FAILURES.values() for lst in d.values())
+    assert len(tunes) == NORBECK_IRISH_COUNT - n_exp_fail
 
     assert 0 < len(jigs) < len(tunes)
     assert all(t in tunes for t in jigs)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -27,6 +27,8 @@ def test_example_random():
 def test_norbeck_load():
     # NOTE: downloads files if not already present
 
+    # TODO: test Norbeck all matches number of `X:`s in those files
+    # TODO: test Norbeck `X` values in files are all unique
     tunes = norbeck.load()  # all
     jigs = norbeck.load("jigs")  # jigs only
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -121,6 +121,9 @@ def test_the_session_load_meta_invalid():
     with pytest.raises(ValueError):
         _ = the_session.load_meta("asdf")
 
+    with pytest.raises(ValueError):
+        _ = the_session.load_meta("sessions", format="asdf")
+
 
 def test_int_downcast():
     import numpy as np

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -122,6 +122,34 @@ def test_the_session_load_meta_invalid():
         _ = the_session.load_meta("asdf")
 
 
+def test_int_downcast():
+    import numpy as np
+    import pandas as pd
+
+    for x, expected_dtype, expected_dtype_ext in [
+        # short short (8)
+        ([int(1e2)], np.uint8, pd.UInt8Dtype()),
+        ([int(1e2), -1], np.int8, pd.Int8Dtype()),
+        # short (16)
+        ([int(1e4)], np.uint16, pd.UInt16Dtype()),
+        ([int(1e4), -1], np.int16, pd.Int16Dtype()),
+        # long (32)
+        ([int(1e9)], np.uint32, pd.UInt32Dtype()),
+        ([int(1e9), -1], np.int32, pd.Int32Dtype()),
+        # long long (64)
+        ([int(1e18)], np.uint64, pd.UInt64Dtype()),
+        ([int(1e18), -1], np.int64, pd.Int64Dtype()),
+    ]:
+        s = pd.Series(x)
+        assert s.dtype == np.int64
+
+        s2 = s.astype(the_session._choose_int_type(s))
+        assert s2.dtype == expected_dtype
+
+        s3 = s.astype(the_session._choose_int_type(s, ext=True))
+        assert s3.dtype == expected_dtype_ext
+
+
 def test_load_url():
     tune = load_url("https://thesession.org/tunes/10000")
     assert tune.title == "Brian Quinn's"

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2,7 +2,7 @@ import pytest
 
 from pyabc2 import Key
 from pyabc2.parse import Tune
-from pyabc2.sources import examples, load_example, load_example_abc, norbeck, the_session
+from pyabc2.sources import examples, load_example, load_example_abc, load_url, norbeck, the_session
 
 
 @pytest.mark.parametrize("tune_name", examples)
@@ -63,3 +63,14 @@ def test_the_session_load_archive():
     # NOTE: downloads file if not already present
 
     _ = the_session.load(n=5)  # TODO: all? (depending on time)
+
+
+def test_load_url():
+    tune = load_url("https://thesession.org/tunes/10000")
+    assert tune.title == "Brian Quinn's"
+
+    tune = load_url("https://norbeck.nu/abc/display.asp?rhythm=slip+jig&ref=106")
+    assert tune.title == "For The Love Of Music"
+
+    with pytest.raises(NotImplementedError):
+        _ = load_url("https://www.google.com")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -59,6 +59,10 @@ def test_the_session_load_url(url, title, key, type):
     assert tune.title == title
     assert tune.key == Key(key)
     assert tune.type == type
+    if "#" in url:  # Currently always gets set to a specific setting
+        assert tune.url == url
+    if "#" not in url:  # First setting
+        assert tune.header["reference number"] == "1"
 
 
 def test_the_session_url_check():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -23,8 +23,12 @@ def test_norbeck_load():
     jigs = norbeck.load("jigs")  # jigs only
 
     assert 0 < len(jigs) < len(tunes)
+    assert all(t in tunes for t in jigs)
+    assert set(jigs) < set(tunes)
 
     assert type(jigs[0]) is Tune
+
+    assert len(set(jigs)) == len(jigs)
 
     # Some diacritic tests
     assert jigs[512].title == "Buachaillín Buí, An"

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,7 +1,8 @@
 import pytest
 
+from pyabc2 import Key
 from pyabc2.parse import Tune
-from pyabc2.sources import examples, load_example, load_example_abc, norbeck
+from pyabc2.sources import examples, load_example, load_example_abc, norbeck, the_session
 
 
 @pytest.mark.parametrize("tune_name", examples)
@@ -37,3 +38,28 @@ def test_norbeck_load():
 
     with pytest.raises(ValueError):
         norbeck.load("asdf")
+
+
+@pytest.mark.parametrize(
+    "url,title,key,type",
+    [
+        ("https://thesession.org/tunes/182", "The Silver Spear", "D", "reel"),
+        ("https://thesession.org/tunes/182#setting22284", "The Silver Spear", "C", "reel"),
+    ],
+)
+def test_the_session_load_url(url, title, key, type):
+    tune = the_session.load_url(url)
+    assert tune.title == title
+    assert tune.key == Key(key)
+    assert tune.type == type
+
+
+def test_the_session_url_check():
+    with pytest.raises(AssertionError):
+        the_session.load_url("https://www.google.com")
+
+
+def test_the_session_load_archive():
+    # NOTE: downloads file if not already present
+
+    _ = the_session.load(n=5)  # TODO: all? (depending on time)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from pyabc2 import Key
@@ -78,6 +80,30 @@ def test_the_session_load_archive():
 def test_the_session_download_invalid():
     with pytest.raises(ValueError):
         _ = the_session.download("asdf")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "which", ["aliases", "events", "recordings", "sessions", "sets", "tune_popularity", "tunes"]
+)
+def test_the_session_load_meta(which):
+    if which == "sessions":
+        ctx = pytest.warns(UserWarning, match="3 bad lon rows found")
+    else:
+        ctx = warnings.catch_warnings()
+
+    with ctx:
+        df1 = the_session.load_meta(which)
+        df2 = the_session.load_meta(which, downcast_ints=True)
+        df3 = the_session.load_meta(which, convert_dtypes=True)
+        # assert df1.equals(df2)  # TODO
+        assert not (df2.dtypes == df1.dtypes).all()
+        assert not (df3.dtypes == df1.dtypes).all()
+
+
+def test_the_session_load_meta_invalid():
+    with pytest.raises(ValueError):
+        _ = the_session.load_meta("asdf")
 
 
 def test_load_url():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -16,6 +16,11 @@ def test_bad_example_raises():
         load_example_abc("asdf")
 
 
+def test_example_random():
+    tune = load_example()
+    assert type(tune) is Tune
+
+
 @pytest.mark.slow
 def test_norbeck_load():
     # NOTE: downloads files if not already present
@@ -63,6 +68,16 @@ def test_the_session_load_archive():
     # NOTE: downloads file if not already present
 
     _ = the_session.load(n=5)  # TODO: all? (depending on time)
+
+    with pytest.warns(UserWarning, match=r"The Session tune\(s\) failed to load"):
+        tunes1 = the_session.load(n=200)
+        tunes2 = the_session.load(n=200, num_workers=2)
+    assert tunes1 == tunes2
+
+
+def test_the_session_download_invalid():
+    with pytest.raises(ValueError):
+        _ = the_session.download("asdf")
 
 
 def test_load_url():


### PR DESCRIPTION
* load `Tune` from a `thesession.org` URL
* added URL load capability for Norbeck as well, and a `sources.load_url()` that can pick which to use automatically
* load tunes from The Session archive (<https://github.com/adactio/TheSession-data>)
* load metadata files from The Session archive as pandas dataframes
* add pytest-xdist and start using in CI
* Drop Py 3.7 support (pandas did in v1.4)
* Fix/test Norbeck total tune count (allow silently two expected failures, which have chords in them)