### PR TITLE
Conversion to and from Helmholtz

### DIFF
--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -498,6 +498,14 @@ class Pitch:
         cn = self.to_pitch_class()._repr_html_()
         return f"{cn}<sub>{self.octave}</sub>"
 
+    def helmholtz(self) -> str:
+        """Note name in Helmholz pitch notation, e.g. "C," and "c'"."""
+        little_c_octave = self.octave - 3
+        if little_c_octave >= 0:
+            return self.class_name.lower() + "'" * little_c_octave
+        big_c_octave = -self.octave + 2
+        return self.class_name + "," * big_c_octave
+
     def unicode(self):
         """String repr using unicode accidental symbols and unicode subscripts for octave.
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -58,9 +58,9 @@ NICE_C_CHROMATIC_NOTES = ["C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", 
 The more common accidentals are used.
 """
 
-_S_RE_ASCII_ACIDENTALS = r"(?:##|bb|b|#|=)"
-_S_RE_PITCH_CLASS = rf"[A-G]{_S_RE_ASCII_ACIDENTALS}?"
-_S_RE_LOWER_PITCH_CLASS = rf"[a-g]{_S_RE_ASCII_ACIDENTALS}?"
+_S_RE_ASCII_ACCIDENTALS = r"(?:##|bb|b|#|=)"
+_S_RE_PITCH_CLASS = rf"[A-G]{_S_RE_ASCII_ACCIDENTALS}?"
+_S_RE_LOWER_PITCH_CLASS = rf"[a-g]{_S_RE_ASCII_ACCIDENTALS}?"
 _RE_PITCH_CLASS = re.compile(_S_RE_PITCH_CLASS)
 # _S_RE_PITCH_CLASS_ONE_ACC = r"[A-G][\#|b]?"
 _RE_PITCH = re.compile(rf"(?P<pitch_class>{_S_RE_PITCH_CLASS})" r"\s*" r"(?P<octave>[0-9]+)")
@@ -345,7 +345,7 @@ class PitchClass:
             pass
         elif acc_fmt_ == "unicode":
             s = re.sub(
-                _S_RE_ASCII_ACIDENTALS, lambda m: _ACCIDENTAL_ASCII_TO_UNICODE[m.group(0)], s
+                _S_RE_ASCII_ACCIDENTALS, lambda m: _ACCIDENTAL_ASCII_TO_UNICODE[m.group(0)], s
             )
         else:
             raise ValueError("invalid `acc_fmt`")

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -506,6 +506,20 @@ class Pitch:
         big_c_octave = -self.octave + 2
         return self.class_name + "," * big_c_octave
 
+    @classmethod
+    def from_helmholtz(cls, helmholtz_name: str) -> "Pitch":
+        helmholtz_name = helmholtz_name.strip()
+        is_upper = helmholtz_name[0].isupper()
+        helmoltz_re = r"([^,]+)(,*)" if is_upper else r"([^']+)('*)"
+        m = re.fullmatch(helmoltz_re, helmholtz_name)
+        if m is None:
+            raise ValueError(f"invalid helmholtz pitch name '{helmholtz_name}'")
+        pitch_class_name = m.group(1).title()
+        marks = len(m.group(2))
+        octave = -marks + 2 if is_upper else marks + 3
+
+        return Pitch.from_class_name(pitch_class_name, octave)
+
     def unicode(self):
         """String repr using unicode accidental symbols and unicode subscripts for octave.
 
@@ -585,6 +599,7 @@ class Pitch:
         class_value = pitch_class_value(class_name)
 
         p = cls.from_class_value(class_value, octave)
+        # TODO: Why are these attributes being set? Should other from_* methods do the same?
         p._class_name = class_name
         p._octave = octave
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -515,6 +515,10 @@ class Pitch:
 
     @classmethod
     def from_helmholtz(cls, helmholtz_name: str) -> "Pitch":
+        """From Helmholtz pitch notation.
+
+        https://en.wikipedia.org/wiki/Helmholtz_pitch_notation
+        """
         helmholtz_name = helmholtz_name.strip()
         is_upper = helmholtz_name[0].isupper()
         helmoltz_re = (

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -614,7 +614,8 @@ class Pitch:
         class_value = pitch_class_value(class_name)
 
         p = cls.from_class_value(class_value, octave)
-        # TODO: Why are these attributes being set? Should other from_* methods do the same?
+        # Preserve "non-standard" pitch class name input like Cb,
+        # which also affects the value since the octave is set by the natural note name.
         p._class_name = class_name
         p._octave = octave
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -520,7 +520,9 @@ class Pitch:
         https://en.wikipedia.org/wiki/Helmholtz_pitch_notation
         """
         helmholtz_name = helmholtz_name.strip()
-        is_upper = helmholtz_name[0].isupper()
+        is_upper = helmholtz_name[
+            0:1
+        ].isupper()  # Single character range so it doesn't fail on empty string.
         helmoltz_re = (
             rf"({_S_RE_PITCH_CLASS})(,*)" if is_upper else rf"({_S_RE_LOWER_PITCH_CLASS})('*)"
         )

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -520,9 +520,8 @@ class Pitch:
         https://en.wikipedia.org/wiki/Helmholtz_pitch_notation
         """
         helmholtz_name = helmholtz_name.strip()
-        is_upper = helmholtz_name[
-            0:1
-        ].isupper()  # Single character range so it doesn't fail on empty string.
+        # Single character range so it doesn't fail on empty string.
+        is_upper = helmholtz_name[0:1].isupper()
         helmoltz_re = (
             rf"({_S_RE_PITCH_CLASS})(,*)" if is_upper else rf"({_S_RE_LOWER_PITCH_CLASS})('*)"
         )

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -498,8 +498,9 @@ class Pitch:
         cn = self.to_pitch_class()._repr_html_()
         return f"{cn}<sub>{self.octave}</sub>"
 
+    @property
     def helmholtz(self) -> str:
-        """Note name in Helmholz pitch notation, e.g. "C," and "c'"."""
+        """Pitch name in Helmholtz pitch notation, e.g. ``C,`` and ``c'`` (ASCII)."""
         little_c_octave = self.octave - 3
         if little_c_octave >= 0:
             return self.class_name.lower() + "'" * little_c_octave
@@ -513,7 +514,7 @@ class Pitch:
         helmoltz_re = r"([^,]+)(,*)" if is_upper else r"([^']+)('*)"
         m = re.fullmatch(helmoltz_re, helmholtz_name)
         if m is None:
-            raise ValueError(f"invalid helmholtz pitch name '{helmholtz_name}'")
+            raise ValueError(f"invalid Helmholtz pitch name '{helmholtz_name}'")
         pitch_class_name = m.group(1).title()
         marks = len(m.group(2))
         octave = -marks + 2 if is_upper else marks + 3

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -553,6 +553,24 @@ def test_note_to_from_nonimpl(meth):
         ("C", ",,''", 0),
     ],
 )
-def test_abc_doctave_calc(note, oct, expected):
+def test_abc_octave_calc(note, oct, expected):
     fn = partial(_octave_from_abc_parts, base=0)
     assert fn(note, oct) == expected
+
+
+@pytest.mark.parametrize(
+    "scientific,expected_helmholtz",
+    [
+        ("C1", "C,"),
+        ("C2", "C"),
+        ("C3", "c"),
+        ("C4", "c'"),
+        ("C5", "c''"),
+        ("B3", "b"),
+        ("B#3", "b#"),
+        ("D3", "d"),
+    ],
+)
+def test_helmholtz_from_pitch(scientific, expected_helmholtz):
+    pitch = Pitch.from_name(scientific)
+    assert pitch.helmholtz() == expected_helmholtz

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -582,6 +582,7 @@ class TestHelholtz:
     def test_helmholtz_name_and_octave(self, scientific, helmholtz):
         from_helmholtz = Pitch.from_helmholtz(helmholtz)
         from_name = Pitch.from_name(scientific)
+        assert from_helmholtz.name == from_name.name
         assert from_helmholtz.class_name == from_name.class_name
         assert from_helmholtz.octave == from_name.octave
 

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -553,7 +553,7 @@ def test_note_to_from_nonimpl(meth):
         ("C", ",,''", 0),
     ],
 )
-def test_abc_octave_calc(note, oct, expected):
+def test_abc_doctave_calc(note, oct, expected):
     fn = partial(_octave_from_abc_parts, base=0)
     assert fn(note, oct) == expected
 
@@ -574,3 +574,21 @@ def test_abc_octave_calc(note, oct, expected):
 def test_helmholtz_from_pitch(scientific, expected_helmholtz):
     pitch = Pitch.from_name(scientific)
     assert pitch.helmholtz() == expected_helmholtz
+
+
+@pytest.mark.parametrize(
+    "helmholtz,expected_scientific",
+    [
+        ("C,", "C1"),
+        ("C", "C2"),
+        ("c", "C3"),
+        ("c'", "C4"),
+        ("c''", "C5"),
+        ("b", "B3"),
+        ("b#", "B#3"),
+        ("d", "D3"),
+    ],
+)
+def test_pitch_from_helmholtz(helmholtz, expected_scientific):
+    pitch = Pitch.from_helmholtz(helmholtz)
+    assert pitch.name == expected_scientific

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -557,8 +557,9 @@ def test_abc_doctave_calc(note, oct, expected):
 
 
 @pytest.mark.parametrize(
-    "scientific,expected_helmholtz",
+    "scientific,helmholtz",
     [
+        ("C0", "C,,"),
         ("C1", "C,"),
         ("C2", "C"),
         ("C3", "c"),
@@ -566,38 +567,27 @@ def test_abc_doctave_calc(note, oct, expected):
         ("C5", "c''"),
         ("B3", "b"),
         ("B#3", "b#"),
-        ("D3", "d"),
+        ("Cb2", "Cb"),
     ],
 )
-def test_helmholtz_from_pitch(scientific, expected_helmholtz):
-    pitch = Pitch.from_name(scientific)
-    assert pitch.helmholtz == expected_helmholtz
+class TestHelholtz:
+    def test_helmholtz_from_pitch(self, scientific, helmholtz):
+        pitch = Pitch.from_name(scientific)
+        assert pitch.helmholtz == helmholtz
 
-
-@pytest.mark.parametrize(
-    "helmholtz,expected_scientific",
-    [
-        ("C,", "C1"),
-        ("C", "C2"),
-        ("c", "C3"),
-        ("c'", "C4"),
-        ("c''", "C5"),
-        ("b", "B3"),
-        ("b#", "B#3"),
-        ("d", "D3"),
-    ],
-)
-def test_pitch_from_helmholtz(helmholtz, expected_scientific):
-    pitch = Pitch.from_helmholtz(helmholtz)
-    assert pitch.name == expected_scientific
+    def test_pitch_from_helmholtz(self, scientific, helmholtz):
+        pitch = Pitch.from_helmholtz(helmholtz)
+        assert pitch.name == scientific
 
 
 @pytest.mark.parametrize(
     "helmholtz",
     [
+        (""),
+        ("H"),
         ("C'"),
         ("c,"),
-        ("abc"),
+        ("bbbb"),
         ("c###"),
     ],
 )

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -26,7 +26,6 @@ C = Key("Cmaj")
         ("C", 0),
         ("C#", 1),
         ("Db", 1),
-        ("C###", 3),
         ("Eb", 3),
         ("Fbb", 3),
     ],
@@ -41,7 +40,6 @@ def test_pitch_value(name, expected_value):
     [
         ("B##", 13),
         ("Cb", -1),
-        ("Dbbb", -1),
     ],
 )
 def test_pitch_value_acc_outside_octave(name, expected_value):
@@ -573,7 +571,7 @@ def test_abc_doctave_calc(note, oct, expected):
 )
 def test_helmholtz_from_pitch(scientific, expected_helmholtz):
     pitch = Pitch.from_name(scientific)
-    assert pitch.helmholtz() == expected_helmholtz
+    assert pitch.helmholtz == expected_helmholtz
 
 
 @pytest.mark.parametrize(

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -570,7 +570,7 @@ def test_abc_doctave_calc(note, oct, expected):
         ("Cb2", "Cb"),
     ],
 )
-class TestHelholtz:
+class TestHelmholtz:
     def test_helmholtz_from_pitch(self, scientific, helmholtz):
         pitch = Pitch.from_name(scientific)
         assert pitch.helmholtz == helmholtz

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -592,3 +592,17 @@ def test_helmholtz_from_pitch(scientific, expected_helmholtz):
 def test_pitch_from_helmholtz(helmholtz, expected_scientific):
     pitch = Pitch.from_helmholtz(helmholtz)
     assert pitch.name == expected_scientific
+
+
+@pytest.mark.parametrize(
+    "helmholtz",
+    [
+        ("C'"),
+        ("c,"),
+        ("abc"),
+        ("c###"),
+    ],
+)
+def test_invalid_helmholtz(helmholtz):
+    with pytest.raises(ValueError):
+        Pitch.from_helmholtz(helmholtz)

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -579,6 +579,12 @@ class TestHelholtz:
         pitch = Pitch.from_helmholtz(helmholtz)
         assert pitch.name == scientific
 
+    def test_helmholtz_name_and_octave(self, scientific, helmholtz):
+        from_helmholtz = Pitch.from_helmholtz(helmholtz)
+        from_name = Pitch.from_name(scientific)
+        assert from_helmholtz.class_name == from_name.class_name
+        assert from_helmholtz.octave == from_name.octave
+
 
 @pytest.mark.parametrize(
     "helmholtz",

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -602,5 +602,5 @@ def test_pitch_from_helmholtz(helmholtz, expected_scientific):
     ],
 )
 def test_invalid_helmholtz(helmholtz):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid Helmholtz pitch"):
         Pitch.from_helmholtz(helmholtz)


### PR DESCRIPTION
- Fix #38

Hope this is on the right track, but please comment if not.

In `Pitch.from_name`, `_class_name` and `_octave` are being set on the new object: Is this something we should do in every case?

The logic overlaps with `_octave_from_abc_parts`: Easiest just to leave it as-is, but another possibility would be to use the new `from_helmholtz` here.