### PR TITLE
Improve test coverage in `key.py`

### DIFF
--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -359,7 +359,8 @@ class Key:
 
         if match_acc:
             # Select flat or sharp to match the current key name
-            # (haven't identified a case where the result is different than below though)
+            # (haven't identified a case where the result is different than
+            # the default approach below though)
 
             # TODO: PitchClass from value with acc option?
             if "#" in key.name:

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -358,17 +358,21 @@ class Key:
         tonic_ef = tonic.equivalent_flat
 
         if match_acc:
-            # Select flat or sharp to match the current key name
+            # Select accidentals to match the current key name
             # (haven't identified a case where the result is different than
             # the default approach below though)
 
             # TODO: PitchClass from value with acc option?
             if "#" in key.name:
-                if tonic_es.acc == "#":  # single sharp used
+                if tonic_es.acc == key.acc:
                     tonic_name = tonic_es.name
+                else:
+                    raise ValueError(f"unable to match accidentals ({key} -> {tonic_es})")
             elif "b" in key.name:
-                if tonic_ef.acc == "b":  # single flat used
+                if tonic_ef.acc == key.acc:
                     tonic_name = tonic_ef.name
+                else:
+                    raise ValueError(f"unable to match accidentals ({key} -> {tonic_ef})")
             else:
                 tonic_name = tonic.name
 

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -189,7 +189,7 @@ def _scale_intervals(
         raise ValueError(f"expected 7 values, got {len(values)}")
     if values[0] != 0:
         raise ValueError(f"first value should be 0, not {values[0]}")
-    if values[-1] < 12:
+    if not values[-1] < 12:
         raise ValueError(f"last value should be < 12, not {values[-1]}")
 
     if include_upper:

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -185,7 +185,8 @@ def _scale_intervals(
         Whether to return 7 intervals by computing the interval from scale degree 7 to 8,
         by default True.
     """
-    assert len(values) == 7
+    if len(values) != 7:
+        raise ValueError(f"scales should contain 7 intervals, not {len(values)}")
 
     if include_upper:
         values.append(12)

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -203,7 +203,7 @@ def _scale_intervals(
         elif dv == 1:
             interval = "H"
         else:
-            raise ValueError("strange interval (not W/H)")
+            raise ValueError(f"strange interval {dv} (not W/H)")
         intervals.append(interval)
     # TODO: should make a class for interval!
 
@@ -292,8 +292,8 @@ class Key:
 
         try:
             mode = _validate_and_normalize_mode_name(mode)
-        except ValueError:
-            raise ValueError("Unrecognized mode specification '{mode}' from key '{key}'")
+        except ValueError as e:
+            raise ValueError(f"Unrecognized mode specification '{mode}' from key '{key}'") from e
 
         return PitchClass.from_name(base + acc), mode
         # TODO: probably should either return a Key or be private / maybe outside class
@@ -365,8 +365,8 @@ class Key:
                     tonic_name = tonic_es.name
                 elif tonic_ef.nat == new_nat:
                     tonic_name = tonic_ef.name
-                else:
-                    raise Exception
+                else:  # pragma: no cover
+                    raise AssertionError
             else:
                 tonic_name = tonic.name
 

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -359,23 +359,20 @@ class Key:
 
         if match_acc:
             # Select accidentals to match the current key name
-            # (haven't identified a case where the result is different than
+            # (haven't identified a case where a successful result is different than
             # the default approach below though)
 
-            # TODO: PitchClass from value with acc option?
-            if "#" in key.name:
-                if tonic_es.acc == key.acc:
-                    tonic_name = tonic_es.name
-                else:
-                    raise ValueError(f"unable to match accidentals ({key} -> {tonic_es})")
-            elif "b" in key.name:
-                if tonic_ef.acc == key.acc:
-                    tonic_name = tonic_ef.name
-                else:
-                    raise ValueError(f"unable to match accidentals ({key} -> {tonic_ef})")
+            # Note = is allowed for explicit natural, but it wouldn't be added automatically
+            orig_acc = key.acc.replace("=", "")
+            for tonic_cand in [tonic_es, tonic_ef, tonic]:
+                if tonic_cand.acc == orig_acc:
+                    tonic_name = tonic_cand.name
+                    break
             else:
-                tonic_name = tonic.name
-
+                raise ValueError(
+                    f"unable to match accidentals ({key}{mode0} -> "
+                    f"{{{tonic_es}, {tonic_ef}, {tonic}}}{mode})"
+                )
         else:
             # Use the letter that it should be in the scale
             sd0 = MODE_SCALE_DEGREE[mode0]

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -255,14 +255,17 @@ class Key:
             Mode specification, e.g., `m`, `min`, `dor`.
             (Major assumed if mode not specified.)
         """
+        msg = "pass either just `name` or both `tonic` and `mode`"
         if name is not None:
-            assert tonic is None and mode is None, "pass either `name` or `tonic`+`mode`"
+            if not (tonic is None and mode is None):
+                raise ValueError(msg)
             # Handle occasional `K:` line used to indicate default key (C) and tune start
             if name == "":
                 name = "C"
             self.tonic, self._mode = Key.parse_key(name)
         else:
-            assert tonic is not None and mode is not None, "pass either `name` or `tonic`+`mode`"
+            if not (tonic is not None and mode is not None):
+                raise ValueError(msg)
             self.tonic = PitchClass.from_name(tonic)
             self._mode = _validate_and_normalize_mode_name(mode)
 

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -186,7 +186,11 @@ def _scale_intervals(
         by default True.
     """
     if len(values) != 7:
-        raise ValueError(f"scales should contain 7 intervals, not {len(values)}")
+        raise ValueError(f"expected 7 values, got {len(values)}")
+    if values[0] != 0:
+        raise ValueError(f"first value should be 0, not {values[0]}")
+    if values[-1] < 12:
+        raise ValueError(f"last value should be < 12, not {values[-1]}")
 
     if include_upper:
         values.append(12)

--- a/pyabc2/key.py
+++ b/pyabc2/key.py
@@ -339,6 +339,7 @@ class Key:
 
         if match_acc:
             # Select flat or sharp to match the current key name
+            # (haven't identified a case where the result is different than below though)
 
             # TODO: PitchClass from value with acc option?
             if "#" in key.name:

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -236,6 +236,8 @@ class PitchClass:
 
         return pc
 
+    # TODO: PitchClass from value with acc option (to hint name)?
+
     @property
     def equivalent_sharp(self) -> "PitchClass":
         pcnew = self - 1

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -100,3 +100,15 @@ def test_scvs_consistency():
     scvs0 = key.scale_chromatic_values
     scvs = [pc.value_in(key) for pc in key.scale]
     assert scvs0 == scvs
+
+
+def test_str():
+    assert str(Key("C")) == "Cmaj"
+
+
+def test_repr():
+    assert repr(Key("C")) == "Key(tonic=C, mode='Major')"
+
+
+def test_inequality():
+    assert Key("C") != "this is not a Key"

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -5,7 +5,13 @@ from itertools import product
 
 import pytest
 
-from pyabc2.key import CMAJ_LETTERS, MODE_VALUES, Key, _mode_chromatic_scale_degrees
+from pyabc2.key import (
+    CMAJ_LETTERS,
+    MODE_VALUES,
+    Key,
+    _mode_chromatic_scale_degrees,
+    _scale_intervals,
+)
 
 
 def many_possible_key_name_inputs():
@@ -53,11 +59,18 @@ def test_parse_key_invalid_mode_fails():
         Key.parse_key("Bad mode + extras warning")
 
 
-def test_key_sig():
+def test_sharp_key_sig():
     k = Key("Amaj")
     assert k.key_signature == ["F#", "C#", "G#"]
     for n in "FCG":
         assert k.accidentals[n] == "#"
+
+
+def test_flat_key_sig():
+    k = Key("Eb")
+    assert k.key_signature == ["Bb", "Eb", "Ab"]
+    for n in "BEA":
+        assert k.accidentals[n] == "b"
 
 
 def test_relatives():
@@ -127,3 +140,13 @@ def test_repr():
 
 def test_inequality():
     assert Key("C") != "this is not a Key"
+
+
+def test_whole_tone_scale_intervals_fails():
+    with pytest.raises(AssertionError):
+        _scale_intervals([0, 2, 4, 6, 8, 10])
+
+
+def test_blues_scale_intervals_fails():
+    with pytest.raises(ValueError, match=r"strange interval \(not W/H\)"):
+        _scale_intervals([0, 2, 3, 5, 6, 9, 10])

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -175,7 +175,7 @@ def test_beyond_octave_fails():
 
 
 def test_scale_with_large_interval_fails():
-    with pytest.raises(ValueError, match=r"strange interval \(not W/H\)"):
+    with pytest.raises(ValueError, match=r"strange interval 3 \(not W/H\)"):
         _scale_intervals([0, 2, 3, 5, 6, 9, 10])
 
 

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -149,11 +149,11 @@ def test_inequality():
 
 
 def test_whole_tone_scale_intervals_fails():
-    with pytest.raises(ValueError, match=r"should contain 7 intervals, not 6"):
+    with pytest.raises(ValueError, match=r"expected 7 values, got 6"):
         _scale_intervals([0, 2, 4, 6, 8, 10])
 
 
-def test_blues_scale_intervals_fails():
+def test_scale_with_large_interval_fails():
     with pytest.raises(ValueError, match=r"strange interval \(not W/H\)"):
         _scale_intervals([0, 2, 3, 5, 6, 9, 10])
 

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -156,3 +156,33 @@ def test_whole_tone_scale_intervals_fails():
 def test_blues_scale_intervals_fails():
     with pytest.raises(ValueError, match=r"strange interval \(not W/H\)"):
         _scale_intervals([0, 2, 3, 5, 6, 9, 10])
+
+
+def test_print_scale(capsys):
+    Key("C").print_scale()
+    output = capsys.readouterr().out
+    assert output == "C  D  E  F  G  A  B \n"
+
+
+def test_print_scale_degrees_wrt_major(capsys):
+    Key("C").print_scale_degrees_wrt_major()
+    output = capsys.readouterr().out
+    assert output == "1  2  3  4  5  6  7 \n"
+
+
+def test_print_chromatic_scale_degrees(capsys):
+    Key("C").print_chromatic_scale_degrees()
+    output = capsys.readouterr().out
+    assert output == "1  #1 2  #2 3  4  #4 5  #5 6  #6 7 \n"
+
+
+def test_print_scale_chromatic_values(capsys):
+    Key("C").print_scale_chromatic_values()
+    output = capsys.readouterr().out
+    assert output == "0  2  4  5  7  9  11\n"
+
+
+def test_print_intervals(capsys):
+    Key("C").print_intervals()
+    output = capsys.readouterr().out
+    assert output == "W W H W W W H\n"

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -149,7 +149,7 @@ def test_inequality():
 
 
 def test_whole_tone_scale_intervals_fails():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match=r"should contain 7 intervals, not 6"):
         _scale_intervals([0, 2, 4, 6, 8, 10])
 
 

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -91,9 +91,14 @@ def test_mode_chromatic_scale_degrees(mode, acc_format):
     assert all(len(s) in [1, 2, 5] and s[-1:-2:-1] in "1234567" for s in csds)
 
 
-def test_invalid_mode_chromatic_scale_degrees_fails():
+def test_invalid_mode_chromatic_scale_degrees_bad_mode():
     with pytest.raises(ValueError, match="invalid mode name"):
         _mode_chromatic_scale_degrees("invalid")
+
+
+def test_invalid_mode_chromatic_scale_degrees_bad_acc_fmt():
+    with pytest.raises(ValueError, match="invalid `acc_format`"):
+        _mode_chromatic_scale_degrees("ionian", acc_fmt="invalid")
 
 
 @pytest.mark.parametrize("mode", MODE_VALUES)

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -90,6 +90,11 @@ def test_mode_chromatic_scale_degrees(mode, acc_format):
     assert all(len(s) in [1, 2, 5] and s[-1:-2:-1] in "1234567" for s in csds)
 
 
+def test_invalid_mode_chromatic_scale_degrees_fails():
+    with pytest.raises(ValueError, match="invalid mode name"):
+        _mode_chromatic_scale_degrees("invalid")
+
+
 @pytest.mark.parametrize("mode", MODE_VALUES)
 def test_mode_scale_degrees_wrt_major(mode):
     # They should be the same no matter the tonic is.

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -153,6 +153,16 @@ def test_whole_tone_scale_intervals_fails():
         _scale_intervals([0, 2, 4, 6, 8, 10])
 
 
+def test_nonzero_start_fails():
+    with pytest.raises(ValueError, match=r"first value should be 0"):
+        _scale_intervals([1] * 7)
+
+
+def test_beyond_octave_fails():
+    with pytest.raises(ValueError, match=r"last value should be < 12"):
+        _scale_intervals([0, 2, 4, 5, 7, 9, 13])
+
+
 def test_scale_with_large_interval_fails():
     with pytest.raises(ValueError, match=r"strange interval \(not W/H\)"):
         _scale_intervals([0, 2, 3, 5, 6, 9, 10])

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -31,11 +31,26 @@ def many_possible_key_name_inputs():
     return [k + m for k, m in product(keys, modes)]
 
 
-@pytest.mark.parametrize("key_name", many_possible_key_name_inputs())
+@pytest.mark.parametrize("key_name", [""] + many_possible_key_name_inputs())
 def test_parse_key_basic_succeeds(key_name):
     # TODO: could create a shorter version with a few selected examples and mark this one as long
     # Attempt to create key using key string provided.
     Key(name=key_name)
+
+
+def test_default_key():
+    k = Key("")
+    assert k.tonic.name == "C"
+
+
+def test_parse_key_invalid_base_fails():
+    with pytest.raises(ValueError, match="Invalid key specification"):
+        Key.parse_key("X")
+
+
+def test_parse_key_invalid_mode_fails():
+    with pytest.raises(ValueError, match="Unrecognized mode specification"):
+        Key.parse_key("Bad mode + extras warning")
 
 
 def test_key_sig():

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -100,6 +100,15 @@ def test_relatives():
     assert Key("C#").relative("dorian", match_acc=True) == Key("D#dor")
     assert Key("C#").relative("dorian") == Key("D#dor")
 
+    # Note key spec parsing currently only supports single #/b,
+    # while pitch class parsing (used when passing tonic) supports up to 2.
+    assert Key("Cbdorian").relative_major == Key(tonic="Bbb", mode="Major")
+    with pytest.raises(ValueError, match="unable to match accidentals"):
+        Key("Cbdorian").relative("Major", match_acc=True)
+    assert Key("E#major").relative("Dorian") == Key(tonic="F##", mode="Dorian")
+    with pytest.raises(ValueError, match="unable to match accidentals"):
+        Key("E#major").relative("Dorian", match_acc=True)
+
 
 @pytest.mark.parametrize(
     ("mode", "acc_format"), [(m, a) for m, a in product(MODE_VALUES, ["#", "b", "#/b", "b/#"])]

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -182,7 +182,13 @@ def test_print_scale_chromatic_values(capsys):
     assert output == "0  2  4  5  7  9  11\n"
 
 
-def test_print_intervals(capsys):
+def test_print_intervals_wh(capsys):
     Key("C").print_intervals()
     output = capsys.readouterr().out
     assert output == "W W H W W W H\n"
+
+
+def test_print_intervals_dash(capsys):
+    Key("C").print_intervals(fmt="-")
+    output = capsys.readouterr().out
+    assert output == "|--|--|-|--|--|--|-\n"

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -49,6 +49,18 @@ def test_default_key():
     assert k.tonic.name == "C"
 
 
+def test_arg_mix_fails():
+    with pytest.raises(ValueError, match="pass either just `name` or both `tonic` and `mode`"):
+        Key(name="C", tonic="D")
+
+
+def test_tonic_mode_both_needed():
+    # Maybe will default to major in the future, but currently requiring both
+    # be passed and mode be valid.
+    with pytest.raises(ValueError, match="pass either just `name` or both `tonic` and `mode`"):
+        Key(tonic="C")
+
+
 def test_parse_key_invalid_base_fails():
     with pytest.raises(ValueError, match="Invalid key specification"):
         Key.parse_key("X")

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -56,7 +56,8 @@ def test_parse_key_invalid_base_fails():
 
 def test_parse_key_invalid_mode_fails():
     with pytest.raises(ValueError, match="Unrecognized mode specification"):
-        Key.parse_key("Bad mode + extras warning")
+        with pytest.warns(UserWarning, match="extra info"):
+            Key.parse_key("Bad mode + extras warning")
 
 
 def test_sharp_key_sig():

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -81,6 +81,12 @@ def test_relatives():
     assert C.relative("aeolian") == C.relative_minor == Am
     assert Key("Ador").relative_major == Key("G")
 
+    assert Am.relative("major", match_acc=True) == C
+    assert Key("Cb").relative("dorian") == Key("Dbdor")
+    assert Key("Cb").relative("dorian", match_acc=True) == Key("Dbdor")
+    assert Key("C#").relative("dorian", match_acc=True) == Key("D#dor")
+    assert Key("C#").relative("dorian") == Key("D#dor")
+
 
 @pytest.mark.parametrize(
     ("mode", "acc_format"), [(m, a) for m, a in product(MODE_VALUES, ["#", "b", "#/b", "b/#"])]

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -37,7 +37,7 @@ def many_possible_key_name_inputs():
     return [k + m for k, m in product(keys, modes)]
 
 
-@pytest.mark.parametrize("key_name", [""] + many_possible_key_name_inputs())
+@pytest.mark.parametrize("key_name", many_possible_key_name_inputs())
 def test_parse_key_basic_succeeds(key_name):
     # TODO: could create a shorter version with a few selected examples and mark this one as long
     # Attempt to create key using key string provided.


### PR DESCRIPTION
- Towards #30

This improves test coverage in `key.py`: It does not bring it to 100%.
- The largest missing block is in `relative()`: The logic here is complicated and I felt a little out of my depth.
- Capturing stdout to test the `print_*()` methods is possible... but before investing time there, wondering if it would make sense to replace these with methods that return formatted string? But maybe for the sake of convenience, format and print in one function is better...
- Tests now hit a line that produces a warning... It would be possible to mock `warnings` to make sure the warning happens where we expect, but not emit the _actual_ warning during the test run.

`_scale_intervals()` brings up a couple questions:
- I have thought that `assert` is not the best tool for input validation, because it may not be evaluated in all environments, but this is a stylistic preference.
- Beyond that, there are useful scales with larger intervals or fewer notes... but since this is a private method, maybe it makes sense to be strict, and throw an error if this code has generated a scale with a weird structure.

This has been a good refresher on python and music theory, but I'm not blocked: I'm happy to revise if you have comments, but I don't want to create work for you either.