### PR TITLE
Fix double sharp/flat HTML repr

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,6 +3,7 @@
 ## v0.1.1 (unreleased)
 
 * Fix loading The Session sets data ({pull}`77`)
+* Fix HTML display of pitch classes with double accidentals ({pull}`76`)
 
 ## v0.1.0 (2025-07-02)
 

--- a/pyabc2/pitch.py
+++ b/pyabc2/pitch.py
@@ -227,8 +227,7 @@ class PitchClass:
         return f"{type(self).__name__}(value={self.value}, name={self.name!r})"
 
     def _repr_html_(self):
-        name = self.name
-        return name[0] + "".join(_ACCIDENTAL_ASCII_TO_HTML[c] for c in name[1:])
+        return f"{self.nat}{_ACCIDENTAL_ASCII_TO_HTML[self.acc]}"
 
     def unicode(self):
         """String repr using unicode accidental symbols.

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -218,6 +218,21 @@ def test_pitch_class_unicode(s, expected):
 @pytest.mark.parametrize(
     "s, expected",
     [
+        ("A", "A"),
+        ("Ab", "A&flat;"),
+        ("Abb", "A&#119083;"),
+        ("A#", "A&sharp;"),
+        ("A##", "A&#119082;"),
+        ("A=", "A&natural;"),
+    ],
+)
+def test_pitch_class_html(s, expected):
+    assert PitchClass.from_name(s)._repr_html_() == expected
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
         ("A4", "A₄"),
         ("A14", "A₁₄"),
         ("Ab4", "A♭₄"),


### PR DESCRIPTION
The special double sharp/flat symbols weren't being used by `PitchClass._repr_html_()`, while `.unicode()` _was_ using them. Now they both are.